### PR TITLE
Fix lilypad dependency

### DIFF
--- a/gub/specs/lilypad.py
+++ b/gub/specs/lilypad.py
@@ -3,6 +3,7 @@ from gub import target
 
 class LilyPad (target.AutoBuild):
     source = 'http://lilypond.org/download/gub-sources/lilypad/lilypad-0.1.1.0-src.tar.bz2'
+    dependencies = [ 'tools::automake' ]
     destdir_install_broken = True
     license_files = ['']
 


### PR DESCRIPTION
Building of lilypad requires the aclocal command
contained in an automake package. 
However, automake was not built when building only lilypad. 
Then, automake is added to the dependency of lilypad.