### PR TITLE
Delete {mingw|cygwin}::lilypond LDFLAGS libpython for lilypond's issue4347

### DIFF
--- a/gub/specs/cygwin/lilypond.py
+++ b/gub/specs/cygwin/lilypond.py
@@ -24,10 +24,9 @@ sheet music from a high-level description file.'''
                                                ]
     configure_flags = (lilypond.LilyPond.configure_flags
                        .replace ('--enable-relocation', '--disable-relocation'))
-    python_lib = '%(system_prefix)s/bin/libpython*.dll'
     LDFLAGS = '-L%(system_prefix)s/lib -L%(system_prefix)s/bin -L%(system_prefix)s/lib/w32api'
     make_flags = (lilypond.LilyPond.make_flags
-                  + ' LDFLAGS="%(LDFLAGS)s %(python_lib)s"')
+                  + ' LDFLAGS="%(LDFLAGS)s"')
 #    branch = 'stable/2.12'
     def __init__ (self, settings, source):
         lilypond.LilyPond.__init__ (self, settings, source)

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -61,7 +61,7 @@ sheet music from a high-level description file.'''
                        + ' --enable-relocation'
                        + ' --enable-rpath'
                        + ' --disable-documentation'
-                       + ' --with-ncsb-dir=%(system_prefix)s/share/fonts/default/Type1'
+                       + ' --with-fonts-dir=%(system_prefix)s/share/fonts/default/Type1'
                        )
     make_flags = ' TARGET_PYTHON=/usr/bin/python'
 

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -173,9 +173,6 @@ class LilyPond__mingw (LilyPond):
             'tools::icoutils',
             'mingw-w64-runtime-winpthread-dll',
             ]
-    python_lib = '%(system_prefix)s/bin/libpython*.dll'
-    make_flags = (LilyPond.make_flags
-                  + ' LDFLAGS="%(python_lib)s"'  % locals ())
     # ugh Python hack: C&P Cygwin
     def compile (self):
         self.system ('''


### PR DESCRIPTION
lilypond's issue4347 set LDFLAGS to build python modules.
So, GUB can be deleted {mingw|cygwin}::lilypond LDFLAGS libpython.
http://code.google.com/p/lilypond/issues/detail?id=4347
https://codereview.appspot.com/227850044

It has been pushed.
http://git.savannah.gnu.org/gitweb/?p=lilypond.git;a=commit;h=2eb22fd223cd56a2dd90eda1499dadbcbfa5fad5