### PR TITLE
Install libertine

### DIFF
--- a/gub/installer.py
+++ b/gub/installer.py
@@ -223,6 +223,8 @@ class Installer (context.RunnableContext):
             'lib/fonts/[^hf]*',
             'share/mkspecs',
             'share/terminfo',
+# GUB's internal fonts directory settings
+            'etc/fonts/conf.d/98-gub-fonts-dir.conf',
             ]
 
         # FIXME: why are we removing these, we need these in a root image.

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -21,9 +21,9 @@ does not depend on the X Window System.  It is designed to locate
 fonts within the system and select them according to requirements
 specified by applications.'''
 
-    source = 'http://fontconfig.org/release/fontconfig-2.8.0.tar.gz'
+    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
-    dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config']
+    dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']
         # FIXME: system dir vs packaging install
         ## UGH  - this breaks  on Darwin!
         ## UGH2 - the added /cross/ breaks Cygwin; possibly need
@@ -86,7 +86,7 @@ rm -f %(srcdir)s/builds/unix/{unix-def.mk,unix-cc.mk,ftconfig.h,freetype-config,
         relax = ''
         if 'stat' in misc.librestrict ():
             relax = 'LIBRESTRICT_IGNORE=%(tools_prefix)s/bin/bash:%(tools_prefix)s/bin/make '
-        for i in ('fc-case', 'fc-lang', 'fc-glyphname', 'fc-arch'):
+        for i in ('fc-case', 'fc-lang', 'fc-glyphname'):
             self.system ('''
 cd %(builddir)s/%(i)s && %(relax)s make "CFLAGS=%(cflags)s" "LIBS=%(libs)s" CPPFLAGS= LD_LIBRARY_PATH=%(tools_prefix)s/lib LDFLAGS=-L%(tools_prefix)s/lib INCLUDES=
 ''', locals ())
@@ -140,10 +140,10 @@ class Fontconfig__freebsd (Fontconfig__linux):
 class Fontconfig__tools (tools.AutoBuild):
     # FIXME: use mi to get to source?
     #source = 'git://anongit.freedesktop.org/git/fontconfig?revision=' + version
-    source = 'http://fontconfig.org/release/fontconfig-2.8.0.tar.gz'
+    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
     def patch (self):
         self.dump ('\nAC_SUBST(LT_AGE)', '%(srcdir)s/configure.in', mode='a', permissions=octal.o755)
         tools.AutoBuild.patch (self)
-    dependencies = ['libtool', 'freetype', 'expat', 'pkg-config']
+    dependencies = ['libtool', 'freetype', 'expat', 'pkg-config', 'bzip2']
     make_flags = ('man_MANS=' # either this, or add something like tools::docbook-utils
                 + ' DOCSRC="" ')

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -97,8 +97,16 @@ cd %(builddir)s/%(i)s && %(relax)s make "CFLAGS=%(cflags)s" "LIBS=%(libs)s" CPPF
 set FONTCONFIG_PATH=$INSTALLER_PREFIX/etc/fonts
 ''', 
              '%(install_prefix)s/etc/relocate/fontconfig.reloc')
-        
-        
+        self.dump ('''<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+        <!-- GUB's internal fonts directory -->
+        <dir>%(system_prefix)s/share/fonts</dir>
+        <dir>%(tools_prefix)s/share/fonts</dir>
+</fontconfig>
+''',
+             '%(install_prefix)s/etc/fonts/conf.d/98-gub-fonts-dir.conf')
+
 class Fontconfig__mingw (Fontconfig):
     def patch (self):
         Fontconfig.patch (self)
@@ -147,3 +155,13 @@ class Fontconfig__tools (tools.AutoBuild):
     dependencies = ['libtool', 'freetype', 'expat', 'pkg-config', 'bzip2']
     make_flags = ('man_MANS=' # either this, or add something like tools::docbook-utils
                 + ' DOCSRC="" ')
+    def install (self):
+        tools.AutoBuild.install (self)
+        self.dump ('''<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+        <!-- GUB's internal fonts directory -->
+        <dir>%(tools_prefix)s/share/fonts</dir>
+</fontconfig>
+''',
+             '%(install_prefix)s/etc/fonts/conf.d/98-gub-fonts-dir.conf')

--- a/gub/specs/libertine-fonts.py
+++ b/gub/specs/libertine-fonts.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Libertine_fonts (build.BinaryBuild):
+    source = 'http://sourceforge.net/projects/linuxlibertine/files/linuxlibertine/5.3.0/LinLibertineOTF_5.3.0_2012_07_02.tgz&strip=0'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/linux-libertine')
+        self.system ('cp %(srcdir)s/* %(install_prefix)s/share/fonts/opentype/linux-libertine/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Libertine_fonts__tools (tools.AutoBuild, Libertine_fonts):
+    pass

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -12,6 +12,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::imagemagick',
                 'tools::rsync', # ugh, we depend on *rsync* !?
                 #'tools::texlive',
+                'tools::libertine-fonts',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/sourcefiles/lilypond-sharhead.sh
+++ b/sourcefiles/lilypond-sharhead.sh
@@ -246,17 +246,6 @@ cd ${bindir};
     done
 cd - > /dev/null;
 
-
-## fontconfig lily fonts
-mkdir -p ${prefix}/usr/etc/fonts/conf.d
-cat <<EOF > ${prefix}/usr/etc/fonts/conf.d/00-lilypond.conf
-<?xml version="1.0"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig>
-        <dir>${prefix}/usr/share/lilypond/current/fonts/otf</dir>
-</fontconfig>
-EOF
-
 ###################
 ## uninstall script
 


### PR DESCRIPTION
In association with Issue 952
https://code.google.com/p/lilypond/issues/detail?id=952

LilyPond's `make doc' will require Linux Libertine fonts.
So this pull request adding to install them to GUB environment.
Would you merge this?