### PR TITLE
Install required fonts

### DIFF
--- a/gub/installer.py
+++ b/gub/installer.py
@@ -223,6 +223,8 @@ class Installer (context.RunnableContext):
             'lib/fonts/[^hf]*',
             'share/mkspecs',
             'share/terminfo',
+# GUB's internal fonts directory settings
+            'etc/fonts/conf.d/98-gub-fonts-dir.conf',
             ]
 
         # FIXME: why are we removing these, we need these in a root image.

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -21,9 +21,9 @@ does not depend on the X Window System.  It is designed to locate
 fonts within the system and select them according to requirements
 specified by applications.'''
 
-    source = 'http://fontconfig.org/release/fontconfig-2.8.0.tar.gz'
+    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
-    dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config']
+    dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']
         # FIXME: system dir vs packaging install
         ## UGH  - this breaks  on Darwin!
         ## UGH2 - the added /cross/ breaks Cygwin; possibly need
@@ -86,7 +86,7 @@ rm -f %(srcdir)s/builds/unix/{unix-def.mk,unix-cc.mk,ftconfig.h,freetype-config,
         relax = ''
         if 'stat' in misc.librestrict ():
             relax = 'LIBRESTRICT_IGNORE=%(tools_prefix)s/bin/bash:%(tools_prefix)s/bin/make '
-        for i in ('fc-case', 'fc-lang', 'fc-glyphname', 'fc-arch'):
+        for i in ('fc-case', 'fc-lang', 'fc-glyphname'):
             self.system ('''
 cd %(builddir)s/%(i)s && %(relax)s make "CFLAGS=%(cflags)s" "LIBS=%(libs)s" CPPFLAGS= LD_LIBRARY_PATH=%(tools_prefix)s/lib LDFLAGS=-L%(tools_prefix)s/lib INCLUDES=
 ''', locals ())
@@ -140,10 +140,10 @@ class Fontconfig__freebsd (Fontconfig__linux):
 class Fontconfig__tools (tools.AutoBuild):
     # FIXME: use mi to get to source?
     #source = 'git://anongit.freedesktop.org/git/fontconfig?revision=' + version
-    source = 'http://fontconfig.org/release/fontconfig-2.8.0.tar.gz'
+    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
     def patch (self):
         self.dump ('\nAC_SUBST(LT_AGE)', '%(srcdir)s/configure.in', mode='a', permissions=octal.o755)
         tools.AutoBuild.patch (self)
-    dependencies = ['libtool', 'freetype', 'expat', 'pkg-config']
+    dependencies = ['libtool', 'freetype', 'expat', 'pkg-config', 'bzip2']
     make_flags = ('man_MANS=' # either this, or add something like tools::docbook-utils
                 + ' DOCSRC="" ')

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -97,8 +97,16 @@ cd %(builddir)s/%(i)s && %(relax)s make "CFLAGS=%(cflags)s" "LIBS=%(libs)s" CPPF
 set FONTCONFIG_PATH=$INSTALLER_PREFIX/etc/fonts
 ''', 
              '%(install_prefix)s/etc/relocate/fontconfig.reloc')
-        
-        
+        self.dump ('''<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+        <!-- GUB's internal fonts directory -->
+        <dir>%(system_prefix)s/share/fonts</dir>
+        <dir>%(tools_prefix)s/share/fonts</dir>
+</fontconfig>
+''',
+             '%(install_prefix)s/etc/fonts/conf.d/98-gub-fonts-dir.conf')
+
 class Fontconfig__mingw (Fontconfig):
     def patch (self):
         Fontconfig.patch (self)
@@ -147,3 +155,13 @@ class Fontconfig__tools (tools.AutoBuild):
     dependencies = ['libtool', 'freetype', 'expat', 'pkg-config', 'bzip2']
     make_flags = ('man_MANS=' # either this, or add something like tools::docbook-utils
                 + ' DOCSRC="" ')
+    def install (self):
+        tools.AutoBuild.install (self)
+        self.dump ('''<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+        <!-- GUB's internal fonts directory -->
+        <dir>%(tools_prefix)s/share/fonts</dir>
+</fontconfig>
+''',
+             '%(install_prefix)s/etc/fonts/conf.d/98-gub-fonts-dir.conf')

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -22,6 +22,12 @@ fonts within the system and select them according to requirements
 specified by applications.'''
 
     source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
+    patches = [
+        # This patch will be unnecessary from fontconfig-2.11.91.
+        'fontconfig-2.11.1-texgyre-aliases.patch',
+        # This patch will be unnecessary from fontconfig-2.11.91.
+        'fontconfig-2.11.1-new-urw-aliases.patch',
+    ]
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
     dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']
         # FIXME: system dir vs packaging install

--- a/gub/specs/fonts-bitstream-charter.py
+++ b/gub/specs/fonts-bitstream-charter.py
@@ -1,0 +1,14 @@
+from gub import tools
+from gub import build
+
+class Fonts_bitstream_charter (build.BinaryBuild):
+    source = 'http://mirrors.ctan.org/fonts/charter.zip'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/bitstream/charter')
+        self.system ('cp %(srcdir)s/charter/*.afm %(install_prefix)s/share/fonts/type1/bitstream/charter/')
+        self.system ('cp %(srcdir)s/charter/*.pf? %(install_prefix)s/share/fonts/type1/bitstream/charter/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_bitstream_charter__tools (tools.AutoBuild, Fonts_bitstream_charter):
+    pass

--- a/gub/specs/fonts-bitstream-vera.py
+++ b/gub/specs/fonts-bitstream-vera.py
@@ -1,0 +1,14 @@
+from gub import tools
+from gub import build
+
+class Fonts_bitstream_vera (build.BinaryBuild):
+    source = 'http://ftp.gnome.org/pub/GNOME/sources/ttf-bitstream-vera/1.10/ttf-bitstream-vera-1.10.tar.bz2'
+    dependencies = ['tools::bzip2']
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/bitstream/vera')
+        self.system ('cp %(srcdir)s/*.ttf %(install_prefix)s/share/fonts/truetype/bitstream/vera/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_bitstream_vera__tools (tools.AutoBuild, Fonts_bitstream_vera):
+    pass

--- a/gub/specs/fonts-dejavu.py
+++ b/gub/specs/fonts-dejavu.py
@@ -1,0 +1,14 @@
+from gub import tools
+from gub import build
+
+class Fonts_dejavu (build.BinaryBuild):
+    source = 'http://sourceforge.net/projects/dejavu/files/dejavu/2.35/dejavu-fonts-ttf-2.35.tar.bz2'
+    dependencies = ['tools::bzip2']
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/dejavu')
+        self.system ('cp %(srcdir)s/ttf/*.ttf %(install_prefix)s/share/fonts/truetype/dejavu/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_dejavu__tools (tools.AutoBuild, Fonts_dejavu):
+    pass

--- a/gub/specs/fonts-ipafont.py
+++ b/gub/specs/fonts-ipafont.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Fonts_ipafont (build.BinaryBuild):
+    source = 'http://download.forest.impress.co.jp/pub/library/i/ipafont/10483/IPAfont00303.zip'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/ipafont')
+        self.system ('cp %(srcdir)s/IPAfont00303/*.ttf %(install_prefix)s/share/fonts/opentype/ipafont/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_ipafont__tools (tools.AutoBuild, Fonts_ipafont):
+    pass

--- a/gub/specs/fonts-liberation.py
+++ b/gub/specs/fonts-liberation.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Fonts_liberation (build.BinaryBuild):
+    source = 'https://fedorahosted.org/releases/l/i/liberation-fonts/liberation-fonts-ttf-2.00.1.tar.gz'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/liberation')
+        self.system ('cp %(srcdir)s/*.ttf %(install_prefix)s/share/fonts/truetype/liberation/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_liberation__tools (tools.AutoBuild, Fonts_liberation):
+    pass

--- a/gub/specs/fonts-libertine.py
+++ b/gub/specs/fonts-libertine.py
@@ -1,7 +1,7 @@
 from gub import tools
 from gub import build
 
-class Libertine_fonts (build.BinaryBuild):
+class Fonts_libertine (build.BinaryBuild):
     source = 'http://sourceforge.net/projects/linuxlibertine/files/linuxlibertine/5.3.0/LinLibertineOTF_5.3.0_2012_07_02.tgz&strip=0'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/linux-libertine')
@@ -9,5 +9,5 @@ class Libertine_fonts (build.BinaryBuild):
     def package (self):
         build.AutoBuild.package (self)
 
-class Libertine_fonts__tools (tools.AutoBuild, Libertine_fonts):
+class Fonts_libertine__tools (tools.AutoBuild, Fonts_libertine):
     pass

--- a/gub/specs/fonts-libertine.py
+++ b/gub/specs/fonts-libertine.py
@@ -5,7 +5,7 @@ class Fonts_libertine (build.BinaryBuild):
     source = 'http://sourceforge.net/projects/linuxlibertine/files/linuxlibertine/5.3.0/LinLibertineOTF_5.3.0_2012_07_02.tgz&strip=0'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/linux-libertine')
-        self.system ('cp %(srcdir)s/* %(install_prefix)s/share/fonts/opentype/linux-libertine/')
+        self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/linux-libertine/')
     def package (self):
         build.AutoBuild.package (self)
 

--- a/gub/specs/fonts-luximono.py
+++ b/gub/specs/fonts-luximono.py
@@ -1,0 +1,14 @@
+from gub import tools
+from gub import build
+
+class Fonts_luximono (build.BinaryBuild):
+    source = 'http://mirrors.ctan.org/fonts/LuxiMono.zip'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/luximono')
+        self.system ('cp %(srcdir)s/LuxiMono/*.afm %(install_prefix)s/share/fonts/type1/luximono/')
+        self.system ('cp %(srcdir)s/LuxiMono/*.pf? %(install_prefix)s/share/fonts/type1/luximono/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_luximono__tools (tools.AutoBuild, Fonts_luximono):
+    pass

--- a/gub/specs/fonts-texgyre.py
+++ b/gub/specs/fonts-texgyre.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Fonts_texgyre (build.BinaryBuild):
+    source = 'http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-2.005otf.zip'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/texgyre')
+        self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/texgyre/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_texgyre__tools (tools.AutoBuild, Fonts_texgyre):
+    pass

--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -1,0 +1,14 @@
+from gub import tools
+from gub import build
+
+class Fonts_urw_core35 (build.BinaryBuild):
+    source = 'git://git.ghostscript.com/urw-core35-fonts.git'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
+        self.system ('cp %(srcdir)s/*.afm %(install_prefix)s/share/fonts/type1/urw-core35/')
+        self.system ('cp %(srcdir)s/*.pf? %(install_prefix)s/share/fonts/type1/urw-core35/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_urw_core35__tools (tools.AutoBuild, Fonts_urw_core35):
+    pass

--- a/gub/specs/libertine-fonts.py
+++ b/gub/specs/libertine-fonts.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Libertine_fonts (build.BinaryBuild):
+    source = 'http://sourceforge.net/projects/linuxlibertine/files/linuxlibertine/5.3.0/LinLibertineOTF_5.3.0_2012_07_02.tgz&strip=0'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/linux-libertine')
+        self.system ('cp %(srcdir)s/* %(install_prefix)s/share/fonts/opentype/linux-libertine/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Libertine_fonts__tools (tools.AutoBuild, Libertine_fonts):
+    pass

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -19,6 +19,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-liberation',
                 'tools::fonts-urw-core35',
                 'tools::fonts-luximono',
+                'tools::fonts-ipafont',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -13,6 +13,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::rsync', # ugh, we depend on *rsync* !?
                 #'tools::texlive',
                 'tools::fonts-libertine',
+                'tools::fonts-bitstream-charter',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -12,6 +12,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::imagemagick',
                 'tools::rsync', # ugh, we depend on *rsync* !?
                 #'tools::texlive',
+                'tools::libertine-fonts',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -12,7 +12,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::imagemagick',
                 'tools::rsync', # ugh, we depend on *rsync* !?
                 #'tools::texlive',
-                'tools::libertine-fonts',
+                'tools::fonts-libertine',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -17,6 +17,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-bitstream-vera',
                 'tools::fonts-liberation',
                 'tools::fonts-urw-core35',
+                'tools::fonts-luximono',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -12,6 +12,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::imagemagick',
                 'tools::rsync', # ugh, we depend on *rsync* !?
                 #'tools::texlive',
+                'tools::fonts-dejavu',
                 'tools::fonts-libertine',
                 'tools::fonts-bitstream-charter',
                 'tools::fonts-bitstream-vera',

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -14,6 +14,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 #'tools::texlive',
                 'tools::fonts-libertine',
                 'tools::fonts-bitstream-charter',
+                'tools::fonts-bitstream-vera',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -15,6 +15,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-libertine',
                 'tools::fonts-bitstream-charter',
                 'tools::fonts-bitstream-vera',
+                'tools::fonts-liberation',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -16,6 +16,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-bitstream-charter',
                 'tools::fonts-bitstream-vera',
                 'tools::fonts-liberation',
+                'tools::fonts-urw-core35',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -5,6 +5,17 @@ from gub import target
 from gub.specs import lilypond
 
 class LilyPond_test (lilypond.LilyPond_base):
+    dependencies = (lilypond.LilyPond_base.dependencies
+                + [
+                'tools::fonts-dejavu',
+                'tools::fonts-libertine',
+                'tools::fonts-bitstream-charter',
+                'tools::fonts-bitstream-vera',
+                'tools::fonts-liberation',
+                'tools::fonts-urw-core35',
+                'tools::fonts-luximono',
+                'tools::fonts-ipafont',
+                ])
     @context.subst_method
     def test_ball (self):
         return '%(uploads)s/lilypond-%(version)s-%(build_number)s.test-output.tar.bz2'

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -36,6 +36,7 @@ sheet music from a high-level description file.'''
         'pango-devel',
         'python-devel',
         'urw-fonts',
+        'tools::fonts-texgyre',
 
         'tools::autoconf',
         'tools::bison',
@@ -62,6 +63,7 @@ sheet music from a high-level description file.'''
                        + ' --enable-rpath'
                        + ' --disable-documentation'
                        + ' --with-fonts-dir=%(system_prefix)s/share/fonts/default/Type1'
+                       + ' --with-texgyre-dir=%(tools_prefix)s/share/fonts/opentype/texgyre'
                        )
     make_flags = ' TARGET_PYTHON=/usr/bin/python'
 

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -35,7 +35,6 @@ sheet music from a high-level description file.'''
         'guile-devel',
         'pango-devel',
         'python-devel',
-        'urw-fonts',
         'tools::fonts-texgyre',
 
         'tools::autoconf',
@@ -62,7 +61,6 @@ sheet music from a high-level description file.'''
                        + ' --enable-relocation'
                        + ' --enable-rpath'
                        + ' --disable-documentation'
-                       + ' --with-fonts-dir=%(system_prefix)s/share/fonts/default/Type1'
                        + ' --with-texgyre-dir=%(tools_prefix)s/share/fonts/opentype/texgyre'
                        )
     make_flags = ' TARGET_PYTHON=/usr/bin/python'

--- a/patches/fontconfig-2.11.1-new-urw-aliases.patch
+++ b/patches/fontconfig-2.11.1-new-urw-aliases.patch
@@ -1,0 +1,308 @@
+From b732bf057f4b3ec3bac539803005e9c42d056b2a Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Thu, 6 Nov 2014 13:15:09 +0900
+Subject: Update aliases for new URW fonts
+
+Patch from Tom Yan
+
+https://bugs.freedesktop.org/show_bug.cgi?id=85225
+
+diff --git a/conf.d/30-metric-aliases.conf b/conf.d/30-metric-aliases.conf
+index 49a9602..cd1e924 100644
+--- a/conf.d/30-metric-aliases.conf
++++ b/conf.d/30-metric-aliases.conf
+@@ -6,17 +6,17 @@
+ 
+ Alias similar/metric-compatible families from various sources:
+ 
+-PostScript fonts:       URW fonts:            GUST fonts:        Windows fonts:
+-======================  ====================  =================  ==================
+-Helvetica               Nimbus Sans L         TeX Gyre Heros
+-Helvetica Condensed                           TeX Gyre Heros Cn
+-Times                   Nimbus Roman No9 L    TeX Gyre Termes
+-Courier                 Nimbus Mono L         TeX Gyre Cursor
+-ITC Avant Garde Gothic  URW Gothic L          TeX Gyre Adventor
+-ITC Bookman             URW Bookman L         TeX Gyre Bonum     Bookman Old Style
+-ITC Zapf Chancery       URW Chancery L        TeX Gyre Chorus
+-Palatino                URW Palladio L        TeX Gyre Pagella   Palatino Linotype
+-New Century Schoolbook  Century Schoolbook L  TeX Gyre Schola    Century Schoolbook
++PostScript fonts:       URW fonts:              GUST fonts:        Windows fonts:
++======================  ======================  =================  ==================
++Helvetica               Nimbus Sans             TeX Gyre Heros
++Helvetica Condensed     Nimbus Sans Narrow      TeX Gyre Heros Cn
++Times                   Nimbus Roman            TeX Gyre Termes
++Courier                 Nimbus Mono             TeX Gyre Cursor
++ITC Avant Garde Gothic  URW Gothic              TeX Gyre Adventor
++ITC Bookman             Bookman URW             TeX Gyre Bonum     Bookman Old Style
++ITC Zapf Chancery       Chancery URW            TeX Gyre Chorus
++Palatino                Palladio URW            TeX Gyre Pagella   Palatino Linotype
++New Century Schoolbook  Century SchoolBook URW  TeX Gyre Schola    Century Schoolbook
+ 
+ Microsoft fonts:  Liberation fonts:       Google CrOS core fonts:  StarOffice fonts:  AMT fonts:
+ ================  ======================  =======================  =================  ==============
+@@ -57,6 +57,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Nimbus Sans</family>
++	  <default>
++	  <family>Helvetica</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Heros</family>
+ 	  <default>
+ 	  <family>Helvetica</family>
+@@ -64,6 +71,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Nimbus Sans Narrow</family>
++	  <default>
++	  <family>Helvetica Condensed</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Heros Cn</family>
+ 	  <default>
+ 	  <family>Helvetica Condensed</family>
+@@ -78,6 +92,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Nimbus Roman</family>
++	  <default>
++	  <family>Times</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Termes</family>
+ 	  <default>
+ 	  <family>Times</family>
+@@ -92,6 +113,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Nimbus Mono</family>
++	  <default>
++	  <family>Courier</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Cursor</family>
+ 	  <default>
+ 	  <family>Courier</family>
+@@ -113,6 +141,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>URW Gothic</family>
++	  <default>
++	  <family>ITC Avant Garde Gothic</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Adventor</family>
+ 	  <default>
+ 	  <family>ITC Avant Garde Gothic</family>
+@@ -134,6 +169,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Bookman URW</family>
++	  <default>
++	  <family>ITC Bookman</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Bonum</family>
+ 	  <default>
+ 	  <family>ITC Bookman</family>
+@@ -162,6 +204,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Chancery URW</family>
++	  <default>
++	  <family>ITC Zapf Chancery</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Chorus</family>
+ 	  <default>
+ 	  <family>ITC Zapf Chancery</family>
+@@ -176,6 +225,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Palladio URW</family>
++	  <default>
++	  <family>Palatino</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Pagella</family>
+ 	  <default>
+ 	  <family>Palatino</family>
+@@ -197,6 +253,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Century SchoolBook URW</family>
++	  <default>
++	  <family>New Century Schoolbook</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Schola</family>
+ 	  <default>
+ 	  <family>New Century Schoolbook</family>
+@@ -401,6 +464,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>Helvetica</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Heros</family>
++	  <family>Nimbus Sans</family>
+ 	  <family>Nimbus Sans L</family>
+ 	  </accept>
+ 	</alias>
+@@ -409,6 +473,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>Helvetica Condensed</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Heros Cn</family>
++	  <family>Nimbus Sans Narrow</family>
+ 	  </accept>
+ 	</alias>
+ 
+@@ -416,6 +481,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>Times</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Termes</family>
++	  <family>Nimbus Roman</family>
+ 	  <family>Nimbus Roman No9 L</family>
+ 	  </accept>
+ 	</alias>
+@@ -424,6 +490,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>Courier</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Cursor</family>
++	  <family>Nimbus Mono</family>
+ 	  <family>Nimbus Mono L</family>
+ 	  </accept>
+ 	</alias>
+@@ -432,6 +499,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>ITC Avant Garde Gothic</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Adventor</family>
++	  <family>URW Gothic</family>
+ 	  <family>URW Gothic L</family>
+ 	  </accept>
+ 	</alias>
+@@ -441,6 +509,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Bookman Old Style</family>
+ 	  <family>TeX Gyre Bonum</family>
++	  <family>Bookman URW</family>
+ 	  <family>URW Bookman L</family>
+ 	  </accept>
+ 	</alias>
+@@ -449,6 +518,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>ITC Zapf Chancery</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Chorus</family>
++	  <family>Chancery URW</family>
+ 	  <family>URW Chancery L</family>
+ 	  </accept>
+ 	</alias>
+@@ -458,6 +528,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Palatino Linotype</family>
+ 	  <family>TeX Gyre Pagella</family>
++	  <family>Palladio URW</family>
+ 	  <family>URW Palladio L</family>
+ 	  </accept>
+ 	</alias>
+@@ -467,6 +538,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Century Schoolbook</family>
+ 	  <family>TeX Gyre Schola</family>
++	  <family>Century SchoolBook URW</family>
+ 	  <family>Century Schoolbook L</family>
+ 	  </accept>
+ 	</alias>
+diff --git a/conf.d/45-latin.conf b/conf.d/45-latin.conf
+index 996fb81..72490f3 100644
+--- a/conf.d/45-latin.conf
++++ b/conf.d/45-latin.conf
+@@ -34,6 +34,10 @@
+ 		<default><family>serif</family></default>
+ 	</alias>
+ 	<alias>
++		<family>Nimbus Roman</family>
++		<default><family>serif</family></default>
++	</alias>
++	<alias>
+ 		<family>Luxi Serif</family>
+ 		<default><family>serif</family></default>
+ 	</alias>
+@@ -97,6 +101,10 @@
+ 		<default><family>sans-serif</family></default>
+ 	</alias>
+ 	<alias>
++		<family>Nimbus Sans</family>
++		<default><family>sans-serif</family></default>
++	</alias>
++	<alias>
+ 		<family>Luxi Sans</family>
+ 		<default><family>sans-serif</family></default>
+ 	</alias>
+@@ -151,6 +159,10 @@
+ 		<family>Nimbus Mono L</family>
+ 		<default><family>monospace</family></default>
+ 	</alias>
++	<alias>
++		<family>Nimbus Mono</family>
++		<default><family>monospace</family></default>
++	</alias>
+ <!--
+   Fantasy faces
+  -->
+diff --git a/conf.d/60-latin.conf b/conf.d/60-latin.conf
+index 2107e31..35600ea 100644
+--- a/conf.d/60-latin.conf
++++ b/conf.d/60-latin.conf
+@@ -10,6 +10,7 @@
+ 			<family>Thorndale AMT</family>
+ 			<family>Luxi Serif</family>
+ 			<family>Nimbus Roman No9 L</family>
++			<family>Nimbus Roman</family>
+ 			<family>Times</family>
+ 		</prefer>
+ 	</alias>
+@@ -23,6 +24,7 @@
+ 			<family>Albany AMT</family>
+ 			<family>Luxi Sans</family>
+ 			<family>Nimbus Sans L</family>
++			<family>Nimbus Sans</family>
+ 			<family>Helvetica</family>
+ 			<family>Lucida Sans Unicode</family>
+ 			<family>BPG Glaho International</family> <!-- lat,cyr,arab,geor -->
+@@ -40,6 +42,7 @@
+ 			<family>Cumberland AMT</family>
+ 			<family>Luxi Mono</family>
+ 			<family>Nimbus Mono L</family>
++			<family>Nimbus Mono</family>
+ 			<family>Courier</family>
+ 		</prefer>
+ 	</alias>
+-- 
+cgit v0.10.2
+

--- a/patches/fontconfig-2.11.1-texgyre-aliases.patch
+++ b/patches/fontconfig-2.11.1-texgyre-aliases.patch
@@ -1,0 +1,43 @@
+From e7121de237a1873c3241a5b8451e7d00a3d41524 Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Fri, 3 Oct 2014 12:26:42 +0900
+Subject: Revert "Bug 73291 - poppler does not show fl ligature"
+
+This reverts commit c6aa4d4bfcbed14f39d070fe7ef90a4b74642ee7.
+
+This issue has been fixed in poppler and we no longer need to patch it out in fontconfig.
+
+diff --git a/conf.d/30-metric-aliases.conf b/conf.d/30-metric-aliases.conf
+index 08c8ba3..49a9602 100644
+--- a/conf.d/30-metric-aliases.conf
++++ b/conf.d/30-metric-aliases.conf
+@@ -77,15 +77,12 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  </default>
+ 	</alias>
+ 
+-<!--
+-     Due to Bug#73291, commented out those lines until the broken font are fixed.
+ 	<alias binding="same">
+ 	  <family>TeX Gyre Termes</family>
+ 	  <default>
+ 	  <family>Times</family>
+ 	  </default>
+ 	</alias>
+--->
+ 
+ 	<alias binding="same">
+ 	  <family>Nimbus Mono L</family>
+@@ -418,10 +415,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	<alias binding="same">
+ 	  <family>Times</family>
+ 	  <accept>
+-<!--
+-     Due to Bug#73291, commented out this line until the broken font are fixed.
+ 	  <family>TeX Gyre Termes</family>
+--->
+ 	  <family>Nimbus Roman No9 L</family>
+ 	  </accept>
+ 	</alias>
+-- 
+cgit v0.10.2
+

--- a/sourcefiles/lilypond-sharhead.sh
+++ b/sourcefiles/lilypond-sharhead.sh
@@ -246,17 +246,6 @@ cd ${bindir};
     done
 cd - > /dev/null;
 
-
-## fontconfig lily fonts
-mkdir -p ${prefix}/usr/etc/fonts/conf.d
-cat <<EOF > ${prefix}/usr/etc/fonts/conf.d/00-lilypond.conf
-<?xml version="1.0"?>
-<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
-<fontconfig>
-        <dir>${prefix}/usr/share/lilypond/current/fonts/otf</dir>
-</fontconfig>
-EOF
-
 ###################
 ## uninstall script
 


### PR DESCRIPTION
In association with Issue 4553
https://code.google.com/p/lilypond/issues/detail?id=4553

LilyPond's `make doc' requires some fonts.
So this pull request adding to install them to GUB environment.
Would you merge this?