### PR TITLE
Updates to URW fonts and Pango

### DIFF
--- a/gub/misc.py
+++ b/gub/misc.py
@@ -164,7 +164,7 @@ def is_ball (s):
     # FIXME: do this properly, by identifying different flavours:
     # .deb, tar.gz, cygwin -[build].tar.bz2 etc and have simple
     # named rules for them.
-    return re.match ('^(.*?)[-_]([0-9].*(-[0-9]+)?)([._][a-z]+[0-9]*)?(\.tar\.(bz2|gz)|\.gu[bp]|\.deb|\.tgz|\.zip)$', s)
+    return re.match ('^(.*?)[-_]([0-9].*(-[0-9]+)?)([._][a-z]+[0-9]*)?(\.tar\.(bz2|gz|xz|lzma)|\.gu[bp]|\.deb|\.tgz|\.txz|\.tlz|\.zip)$', s)
 
 def split_ball (s):
     p = s.rfind ('/')

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -23,6 +23,7 @@ specified by applications.'''
 
     source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
     patches = [
+        'fontconfig-2.11.1-conf-relative-symlink.patch',
         # This patch will be unnecessary from fontconfig-2.11.91.
         'fontconfig-2.11.1-texgyre-aliases.patch',
         # This patch will be unnecessary from fontconfig-2.11.91.

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -155,7 +155,8 @@ class Fontconfig__freebsd (Fontconfig__linux):
 class Fontconfig__tools (tools.AutoBuild):
     # FIXME: use mi to get to source?
     #source = 'git://anongit.freedesktop.org/git/fontconfig?revision=' + version
-    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
+    source = Fontconfig.source
+    patches = Fontconfig.patches
     def patch (self):
         self.dump ('\nAC_SUBST(LT_AGE)', '%(srcdir)s/configure.in', mode='a', permissions=octal.o755)
         tools.AutoBuild.patch (self)

--- a/gub/specs/fonts-gnufreefont.py
+++ b/gub/specs/fonts-gnufreefont.py
@@ -1,0 +1,13 @@
+from gub import tools
+from gub import build
+
+class Fonts_gnufreefont (build.BinaryBuild):
+    source = 'http://ftp.gnu.org/gnu/freefont/freefont-otf-20120503.tar.gz'
+    def install (self):
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/gnufreefont')
+        self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/gnufreefont/')
+    def package (self):
+        build.AutoBuild.package (self)
+
+class Fonts_gnufreefont__tools (tools.AutoBuild, Fonts_gnufreefont):
+    pass

--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -2,7 +2,9 @@ from gub import tools
 from gub import build
 
 class Fonts_urw_core35 (build.BinaryBuild):
-    source = 'git://git.ghostscript.com/urw-core35-fonts.git'
+    # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=c983ed400dc278dcf20bdff68252fad6d9db7af9
+    revision = 'c983ed400dc278dcf20bdff68252fad6d9db7af9'
+    source = 'git://git.ghostscript.com/urw-core35-fonts.git&revision=' + revision
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
         self.system ('cp %(srcdir)s/*.afm %(install_prefix)s/share/fonts/type1/urw-core35/')

--- a/gub/specs/glib.py
+++ b/gub/specs/glib.py
@@ -2,84 +2,70 @@ from gub import gnome
 from gub import misc
 from gub import tools
 from gub import target
-from gub import w32
 
 class Glib (target.AutoBuild):
-    source = 'http://ftp.gnome.org/pub/GNOME/platform/2.27/2.27.91/sources/glib-2.21.5.tar.gz'
-    ##source = 'http://ftp.gnome.org/pub/GNOME/platform/2.25/2.25.5/sources/glib-2.19.5.tar.gz'
-    dependencies = ['tools::glib', 'tools::libtool', 'gettext-devel']
+    source = 'http://ftp.gnome.org/pub/GNOME/sources/glib/2.44/glib-2.44.1.tar.xz'
+    dependencies = ['tools::glib', 'tools::libtool', 'tools::xzutils', 'gettext-devel', 'zlib-devel', 'libffi-devel', ]
     config_cache_overrides = target.AutoBuild.config_cache_overrides + '''
 glib_cv_stack_grows=${glib_cv_stack_grows=no}
-'''
-    if 'stat' in misc.librestrict (): # stats for /USR/include/glib/...
-        install_flags = (target.AutoBuild.install_flags
-                         + ' LD_PRELOAD=%(tools_prefix)s/lib/librestrict-open.so')
-    def patch (self):
-        target.AutoBuild.patch (self)
-        self.file_sub ([('GIO_MODULE_DIR', 'getenv ("GIO_MODULE_DIR")')],
-                       '%(srcdir)s/gio/giomodule.c', must_succeed=True)
-    def update_libtool (self): # linux-x86, linux-ppc, freebsd-x86
-        target.AutoBuild.update_libtool (self)
-        self.map_locate (w32.libtool_disable_relink, '%(builddir)s', 'libtool')
-        #URGME, 2.19.5: relinking libgio is broken, /usr/lib is inserted
-        '''root/usr/lib/usr/lib -L/usr/lib -lgobject-2.0 -L/home/janneke/vc/gub/target/linux-ppc/install/glib-2.19.5-root/usr/lib/home/janneke/vc/gub/target/linux-ppc/build/glib-2.19.5/gmodule/.libs -lgmodule-2.0 -ldl -lglib-2.0    -Wl,-soname -Wl,libgio-2.0.so.0 -Wl,-version-script -Wl,.libs/libgio-2.0.ver -o .libs/libgio-2.0.so.0.1905.0
-/home/janneke/vc/gub/target/linux-ppc/root/usr/cross/bin/powerpc-linux-ld: skipping incompatible /usr/lib/libgobject-2.0.so when searching for -lgobject-2.0
-/home/janneke/vc/gub/target/linux-ppc/root/usr/cross/bin/powerpc-linux-ld: skipping incompatible /usr/lib/libgobject-2.0.a when searching for -lgobject-2.0
-/home/janneke/vc/gub/target/linux-ppc/root/usr/cross/bin/powerpc-linux-ld: cannot find -lgobject-2.0
-collect2: ld returned 1 exit status
-libtool: install: error: relink `libgio-2.0.la' with the above command before installing it
-make[5]: *** [install-libLTLIBRARIES] Error 1
 '''
     def install (self):
         target.AutoBuild.install (self)
         self.system ('rm -f %(install_prefix)s/lib/charset.alias')
 
 class Glib__darwin (Glib):
+    # Darwin 8 SDK (Mac OS X 10.4) can not compile glib 2.45.3+.
+    # It needs OS X 10.9.
+    patches = Glib.patches + ['glib-2.44.1-darwin-in.patch']
     def configure (self):
         Glib.configure (self)
-        self.file_sub ([('nmedit', '%(target_architecture)s-nmedit')],
-                       '%(builddir)s/libtool')
+        self.file_sub ([('-Werror=format=2', '')],
+                       '%(builddir)s/glib/Makefile')
+        self.file_sub ([('-Werror=declaration-after-statement', '')],
+                       '%(builddir)s/gio/Makefile')
 
 class Glib__darwin__x86 (Glib__darwin):
-    # LIBS bugfix from:
-    #   https://bugzilla.gnome.org/show_bug.cgi?id=586150
-    configure_variables = Glib.configure_variables + ' LIBS=-lresolv'
-    def compile (self):
-        self.file_sub ([('(SUBDIRS = .*) tests', r'\1'),
-                        (r'GTESTER = \$.*', ''),
-                        ('(am__EXEEXT(_[0-9])? = )gtester.*', r'\1'),
-                        ('(am__append(_[0-9])? = )gtester', r'\1')],
-                       '%(builddir)s/glib/Makefile', must_succeed=True)
-        Glib__darwin.compile (self)
-        
+    patches = Glib__darwin.patches + [
+        'glib-2.44.1-darwin-x86-lib-depend.patch',
+        'glib-2.44.1-darwin-x86-zlib.patch',
+    ]
+    def patch (self):
+        Glib__darwin.patch (self)
+        # darwin-x86 inline asm seems broken.
+        self.file_sub ([('#define USE_ASM_GOTO 1', '')],
+                       '%(srcdir)s/glib/gbitlock.c')
+
 class Glib__mingw (Glib):
+    patches = Glib.patches + [
+        'glib-2.44.1-mingw-w64-if_nametoindex.patch',
+    ]
     dependencies = Glib.dependencies + ['libiconv-devel']
-    def update_libtool (self): # linux-x86, linux-ppc, freebsd-x86
-        target.AutoBuild.update_libtool (self)
-        self.map_locate (w32.libtool_disable_relink, '%(builddir)s', 'libtool')
+    def configure (self):
+        Glib.configure (self)
+        self.file_sub ([('-Werror=format=2', ''),
+                        ('-Werror=format-extra-args', ''),],
+                       '%(builddir)s/glib/Makefile')
+        self.file_sub ([('-Werror=format=2', ''),
+                        ('-Werror=format-extra-args', ''),],
+                       '%(builddir)s/gobject/Makefile')
+        self.file_sub ([('-Werror=format=2', ''),
+                        ('-Werror=format-extra-args', ''),],
+                       '%(builddir)s/gio/Makefile')
 
 class Glib__freebsd (Glib):
     dependencies = Glib.dependencies + ['libiconv-devel']
-    configure_variables = Glib.configure_variables + ' CFLAGS=-pthread'
-
-class Glib__freebsd__x86 (Glib__freebsd):
-    # Must include -pthread in lib flags, because our most beloved
-    # libtool (2.2.6a) thinks it knows best and blondly strips -pthread
-    # if it thinks it's a compile flag.
-    # FIXME: should add fixup to update_libtool ()
-    make_flags = ' G_THREAD_LIBS=-pthread G_THREAD_LIBS_FOR_GTHREAD=-pthread '
+    # FreeBSD 6 can not compile glib 2.40.0+. It needs FreeBSD 8.1.
+    source = 'http://ftp.gnome.org/pub/GNOME/sources/glib/2.38/glib-2.38.2.tar.xz'
 
 class Glib__tools (tools.AutoBuild, Glib):
     dependencies = [
             'gettext',
             'libtool',
             'pkg-config',
+            'zlib',
+            'libffi',
+            'xzutils',
             ]            
-    configure_flags = (tools.AutoBuild.configure_flags
-                       + ' --build=%(build_architecture)s'
-                       + ' --host=%(build_architecture)s'
-                       + ' --target=%(build_architecture)s'
-                       )
     def install (self):
         tools.AutoBuild.install (self)
         self.system ('rm -f %(install_root)s%(packaging_suffix_dir)s%(prefix_dir)s/lib/charset.alias')

--- a/gub/specs/harfbuzz.py
+++ b/gub/specs/harfbuzz.py
@@ -1,0 +1,15 @@
+from gub import target
+from gub import tools
+
+class Harfbuzz (target.AutoBuild):
+    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.0.2.tar.bz2'
+    dependencies = [
+        'tools::bzip2',
+        'freetype-devel',
+        'glib-devel',
+    ]
+    configure_flags = (target.AutoBuild.configure_flags
+                       + ' --without-cairo' )
+
+class Harfbuzz__tools (tools.AutoBuild, Harfbuzz):
+    pass

--- a/gub/specs/libffi.py
+++ b/gub/specs/libffi.py
@@ -1,4 +1,5 @@
 from gub import target
+from gub import tools
 
 class Libffi (target.AutoBuild):
     source = 'ftp://sourceware.org/pub/libffi/libffi-3.0.9.tar.gz'
@@ -15,3 +16,5 @@ class Libffi (target.AutoBuild):
         self.system ('cd %(install_prefix)s && mv lib/libffi-3.0.9/include .')
         self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.0.9')
                 
+class Libffi__tools (tools.AutoBuild, Libffi):
+    pass

--- a/gub/specs/libffi.py
+++ b/gub/specs/libffi.py
@@ -2,7 +2,7 @@ from gub import target
 from gub import tools
 
 class Libffi (target.AutoBuild):
-    source = 'ftp://sourceware.org/pub/libffi/libffi-3.0.9.tar.gz'
+    source = 'ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz'
     dependencies = [
         'tools::automake',
         'tools::libtool',
@@ -13,8 +13,16 @@ class Libffi (target.AutoBuild):
                      + """ includesdir='$(includedir)' """ )
     def install (self):
         target.AutoBuild.install (self)
-        self.system ('cd %(install_prefix)s && mv lib/libffi-3.0.9/include .')
-        self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.0.9')
-                
+        self.system ('cd %(install_prefix)s && mv lib/libffi-3.2.1/include .')
+        self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.2.1')
+
+class Libffi__darwin__x86 (Libffi):
+    # darwin-x86 can not compile libffi 3.1, 3.2.1.
+    source = 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'
+    def install (self):
+        target.AutoBuild.install (self)
+        self.system ('cd %(install_prefix)s && mv lib/libffi-3.0.13/include .')
+        self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.0.13')
+
 class Libffi__tools (tools.AutoBuild, Libffi):
     pass

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -20,6 +20,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-urw-core35',
                 'tools::fonts-luximono',
                 'tools::fonts-ipafont',
+                'tools::fonts-gnufreefont',
                 'system::makeinfo',
                 'system::zip',
                 ])

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -7,6 +7,7 @@ from gub.specs import lilypond
 class LilyPond_test (lilypond.LilyPond_base):
     dependencies = (lilypond.LilyPond_base.dependencies
                 + [
+                'tools::netpbm',
                 'tools::fonts-dejavu',
                 'tools::fonts-libertine',
                 'tools::fonts-bitstream-charter',

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -16,6 +16,7 @@ class LilyPond_test (lilypond.LilyPond_base):
                 'tools::fonts-urw-core35',
                 'tools::fonts-luximono',
                 'tools::fonts-ipafont',
+                'tools::fonts-gnufreefont',
                 ])
     @context.subst_method
     def test_ball (self):

--- a/patches/fontconfig-2.11.1-conf-relative-symlink.patch
+++ b/patches/fontconfig-2.11.1-conf-relative-symlink.patch
@@ -1,0 +1,14 @@
+--- fontconfig-2.11.1/conf.d/Makefile.in.org	2014-03-24 15:04:15.000000000 +0900
++++ fontconfig-2.11.1/conf.d/Makefile.in	2015-09-06 02:48:55.862653400 +0900
+@@ -633,9 +633,9 @@
+ 	@(echo cd $(DESTDIR)$(configdir);			\
+ 	  cd $(DESTDIR)$(configdir);				\
+ 	  for i in $(CONF_LINKS); do				\
+-	    echo $(RM) $$i";" ln -s $(templatedir)/$$i .;	\
++	    echo $(RM) $$i";" ln -sr $(DESTDIR)$(templatedir)/$$i .;	\
+ 	    $(RM) $$i;						\
+-	    ln -s $(templatedir)/$$i .;				\
++	    ln -sr $(DESTDIR)/$(templatedir)/$$i .;				\
+ 	  done)
+ uninstall-local:
+ 	@(echo cd $(DESTDIR)$(configdir);			\

--- a/patches/glib-2.44.1-darwin-in.patch
+++ b/patches/glib-2.44.1-darwin-in.patch
@@ -1,0 +1,66 @@
+--- glib-2.44.1/gio/gdummyfile.c.org	2014-12-20 06:49:48.000000000 +0900
++++ glib-2.44.1/gio/gdummyfile.c	2015-08-30 11:55:32.577794900 +0900
+@@ -441,7 +441,7 @@
+ 		 const gchar *escaped_string_end,
+ 		 const gchar *illegal_characters)
+ {
+-  const gchar *in;
++  const gchar *in_dummy;
+   gchar *out, *result;
+   gint character;
+   
+@@ -454,19 +454,19 @@
+   result = g_malloc (escaped_string_end - escaped_string + 1);
+ 	
+   out = result;
+-  for (in = escaped_string; in < escaped_string_end; in++) 
++  for (in_dummy = escaped_string; in_dummy < escaped_string_end; in_dummy++) 
+     {
+-      character = *in;
+-      if (*in == '%') 
++      character = *in_dummy;
++      if (*in_dummy == '%') 
+         {
+-          in++;
+-          if (escaped_string_end - in < 2)
++          in_dummy++;
++          if (escaped_string_end - in_dummy < 2)
+ 	    {
+ 	      g_free (result);
+ 	      return NULL;
+ 	    }
+       
+-          character = unescape_character (in);
++          character = unescape_character (in_dummy);
+       
+           /* Check for an illegal character. We consider '\0' illegal here. */
+           if (character <= 0 ||
+@@ -476,7 +476,7 @@
+ 	      g_free (result);
+ 	      return NULL;
+ 	    }
+-          in++; /* The other char will be eaten in the loop header */
++          in_dummy++; /* The other char will be eaten in the loop header */
+         }
+       *out++ = (char)character;
+     }
+@@ -516,7 +516,7 @@
+ _g_decode_uri (const char *uri)
+ {
+   GDecodedUri *decoded;
+-  const char *p, *in, *hier_part_start, *hier_part_end, *query_start, *fragment_start;
++  const char *p, *in_dummy, *hier_part_start, *hier_part_end, *query_start, *fragment_start;
+   char *out;
+   char c;
+ 
+@@ -551,8 +551,8 @@
+   
+   decoded->scheme = g_malloc (p - uri);
+   out = decoded->scheme;
+-  for (in = uri; in < p - 1; in++)
+-    *out++ = g_ascii_tolower (*in);
++  for (in_dummy = uri; in_dummy < p - 1; in_dummy++)
++    *out++ = g_ascii_tolower (*in_dummy);
+   *out = 0;
+ 
+   hier_part_start = p;

--- a/patches/glib-2.44.1-darwin-x86-lib-depend.patch
+++ b/patches/glib-2.44.1-darwin-x86-lib-depend.patch
@@ -1,0 +1,41 @@
+--- glib-2.44.1/gio/Makefile.in.org	2015-05-13 11:50:40.000000000 +0900
++++ glib-2.44.1/gio/Makefile.in	2015-08-30 12:01:11.975858800 +0900
+@@ -1731,6 +1731,7 @@
+ glib_compile_resources_LDADD = libgio-2.0.la 		\
+ 	$(top_builddir)/gobject/libgobject-2.0.la	\
+ 	$(top_builddir)/glib/libglib-2.0.la 		\
++	xdgmime/libxdgmime.la				\
+ 	$(NULL)
+ 
+ glib_compile_resources_SOURCES = \
+@@ -1757,6 +1758,7 @@
+ gsettings_LDADD = libgio-2.0.la 			\
+ 	$(top_builddir)/gobject/libgobject-2.0.la	\
+ 	$(top_builddir)/glib/libglib-2.0.la		\
++	xdgmime/libxdgmime.la				\
+ 	$(NULL)
+ 
+ gsettings_SOURCES = gsettings-tool.c
+@@ -1766,12 +1768,14 @@
+ gdbus_LDADD = libgio-2.0.la 				\
+ 	$(top_builddir)/gobject/libgobject-2.0.la	\
+ 	$(top_builddir)/glib/libglib-2.0.la		\
++	xdgmime/libxdgmime.la				\
+ 	$(NULL)
+ 
+ @OS_UNIX_TRUE@gapplication_SOURCES = gapplication-tool.c
+ @OS_UNIX_TRUE@gapplication_LDADD = libgio-2.0.la 			\
+ @OS_UNIX_TRUE@	$(top_builddir)/gobject/libgobject-2.0.la	\
+ @OS_UNIX_TRUE@	$(top_builddir)/glib/libglib-2.0.la		\
++@OS_UNIX_TRUE@	xdgmime/libxdgmime.la				\
+ @OS_UNIX_TRUE@	$(NULL)
+ 
+ completiondir = $(datadir)/bash-completion/completions
+@@ -1786,6 +1790,7 @@
+ gresource_LDADD = libgio-2.0.la				\
+ 	$(top_builddir)/gobject/libgobject-2.0.la	\
+ 	$(top_builddir)/glib/libglib-2.0.la		\
++	xdgmime/libxdgmime.la				\
+ 	$(LIBELF_LIBS)
+ 
+ all: $(BUILT_SOURCES)

--- a/patches/glib-2.44.1-darwin-x86-zlib.patch
+++ b/patches/glib-2.44.1-darwin-x86-zlib.patch
@@ -1,0 +1,22 @@
+--- glib-2.44.1/gio/gzlibcompressor.c.org	2014-12-20 06:49:48.000000000 +0900
++++ glib-2.44.1/gio/gzlibcompressor.c	2015-08-30 12:07:36.581817200 +0900
+@@ -71,7 +71,7 @@
+ g_zlib_compressor_set_gzheader (GZlibCompressor *compressor)
+ {
+   /* On win32, these functions were not exported before 1.2.4 */
+-#if !defined (G_OS_WIN32) || ZLIB_VERNUM >= 0x1240
++#if 0
+   const gchar *filename;
+ 
+   if (compressor->format != G_ZLIB_COMPRESSOR_FORMAT_GZIP ||
+--- glib-2.44.1/gio/gzlibdecompressor.c.org	2014-12-20 06:49:48.000000000 +0900
++++ glib-2.44.1/gio/gzlibdecompressor.c	2015-08-30 12:07:36.597442900 +0900
+@@ -74,7 +74,7 @@
+ g_zlib_decompressor_set_gzheader (GZlibDecompressor *decompressor)
+ {
+   /* On win32, these functions were not exported before 1.2.4 */
+-#if !defined (G_OS_WIN32) || ZLIB_VERNUM >= 0x1240
++#if 0
+   if (decompressor->format != G_ZLIB_COMPRESSOR_FORMAT_GZIP)
+     return;
+ 

--- a/patches/glib-2.44.1-mingw-w64-if_nametoindex.patch
+++ b/patches/glib-2.44.1-mingw-w64-if_nametoindex.patch
@@ -1,0 +1,44 @@
+--- glib-2.44.1/gio/gsocket.c.org	2015-03-23 03:19:51.000000000 +0900
++++ glib-2.44.1/gio/gsocket.c	2015-08-30 12:11:11.394997300 +0900
+@@ -1939,7 +1939,7 @@
+ 
+ #if !defined(HAVE_IF_NAMETOINDEX) && defined(G_OS_WIN32)
+ static guint
+-if_nametoindex (const gchar *iface)
++if_nametoindex_wrap (const gchar *iface)
+ {
+   PIP_ADAPTER_ADDRESSES addresses = NULL, p;
+   gulong addresses_len = 0;
+@@ -1992,6 +1992,8 @@
+ }
+ 
+ #define HAVE_IF_NAMETOINDEX 1
++#else
++#define if_nametoindex_wrap if_nametoindex
+ #endif
+ 
+ static gboolean
+@@ -2026,12 +2028,12 @@
+ 
+ #ifdef HAVE_IP_MREQN
+       if (iface)
+-        mc_req.imr_ifindex = if_nametoindex (iface);
++        mc_req.imr_ifindex = if_nametoindex_wrap (iface);
+       else
+         mc_req.imr_ifindex = 0;  /* Pick any.  */
+ #elif defined(G_OS_WIN32)
+       if (iface)
+-        mc_req.imr_interface.s_addr = g_htonl (if_nametoindex (iface));
++        mc_req.imr_interface.s_addr = g_htonl (if_nametoindex_wrap (iface));
+       else
+         mc_req.imr_interface.s_addr = g_htonl (INADDR_ANY);
+ #else
+@@ -2064,7 +2066,7 @@
+       memcpy (&mc_req_ipv6.ipv6mr_multiaddr, native_addr, sizeof (struct in6_addr));
+ #ifdef HAVE_IF_NAMETOINDEX
+       if (iface)
+-        mc_req_ipv6.ipv6mr_interface = if_nametoindex (iface);
++        mc_req_ipv6.ipv6mr_interface = if_nametoindex_wrap (iface);
+       else
+ #endif
+         mc_req_ipv6.ipv6mr_interface = 0;

--- a/patches/pango-1.36.8-substitute-env.patch
+++ b/patches/pango-1.36.8-substitute-env.patch
@@ -1,17 +1,6 @@
-From abeddd7a12b1493f2db7ea4b60f0a198991d18a4 Mon Sep 17 00:00:00 2001
-From: Han-Wen Nienhuys <hanwen@lilypond.org>
-Date: Sat, 22 Mar 2008 17:27:52 -0300
-Subject: [PATCH] Pango 1.20 patch for subst env.
-
----
- pango/pango-utils.c |  102 +++++++++++++++++++++++++++++++++++++++++++++++++++
- 1 files changed, 102 insertions(+), 0 deletions(-)
-
-diff --git a/pango/pango-utils.c b/pango/pango-utils.c
-index d2e4992..c2c49d5 100644
---- a/pango/pango-utils.c
-+++ b/pango/pango-utils.c
-@@ -25,6 +25,7 @@
+--- pango-1.36.8/pango/pango-utils.c.orig	2014-08-31 02:02:57.000000000 +0900
++++ pango-1.36.8/pango/pango-utils.c	2015-08-30 21:31:27.361804200 +0900
+@@ -43,6 +43,7 @@
  #include <stdlib.h>
  #include <math.h>
  #include <locale.h>
@@ -19,7 +8,7 @@ index d2e4992..c2c49d5 100644
  
  #include "pango-font.h"
  #include "pango-features.h"
-@@ -171,6 +172,89 @@ pango_trim_string (const char *str)
+@@ -177,6 +178,89 @@
    return g_strndup (str, len);
  }
  
@@ -109,7 +98,7 @@ index d2e4992..c2c49d5 100644
  /**
   * pango_split_file_list:
   * @str: a %G_SEARCHPATH_SEPARATOR separated list of filenames
-@@ -225,6 +309,16 @@ pango_split_file_list (const char *str)
+@@ -232,6 +316,16 @@
  	  file = g_strdup (g_get_home_dir());
  	}
  #endif
@@ -126,15 +115,15 @@ index d2e4992..c2c49d5 100644
        g_free (files[i]);
        files[i] = file;
  
-@@ -407,6 +501,7 @@ pango_scan_word (const char **pos, GString *out)
+@@ -414,6 +508,7 @@
    return TRUE;
  }
  
 +
  /**
   * pango_scan_string:
-  * @pos: in/out string position
-@@ -492,6 +587,13 @@ pango_scan_string (const char **pos, GString *out)
+  * @pos: (inout): in/out string position
+@@ -499,6 +594,13 @@
  	}
      }
  
@@ -148,6 +137,3 @@ index d2e4992..c2c49d5 100644
    *pos = p;
  
    return TRUE;
--- 
-1.5.4.1
-

--- a/patches/pango-1.36.8-test-without-cairo.patch
+++ b/patches/pango-1.36.8-test-without-cairo.patch
@@ -1,0 +1,13 @@
+--- pango-1.36.8/tests/Makefile.in.org	2014-09-23 03:30:19.000000000 +0900
++++ pango-1.36.8/tests/Makefile.in	2015-08-30 13:36:48.925365600 +0900
+@@ -84,8 +84,8 @@
+ @HAVE_WIN32_TRUE@am__append_3 = -DHAVE_WIN32
+ @CROSS_COMPILING_FALSE@TESTS = $(check_PROGRAMS)
+ check_PROGRAMS = testboundaries$(EXEEXT) testboundaries_ucd$(EXEEXT) \
+-	testcolor$(EXEEXT) testscript$(EXEEXT) markup-parse$(EXEEXT) \
+-	test-layout$(EXEEXT) test-font$(EXEEXT) $(am__EXEEXT_1) \
++	testcolor$(EXEEXT) testscript$(EXEEXT) \
++	$(am__EXEEXT_1) \
+ 	$(am__EXEEXT_2) $(am__EXEEXT_3)
+ @HAVE_CAIRO_TRUE@am__append_4 = testiter test-pangocairo-threads
+ @HAVE_FREETYPE_TRUE@am__append_5 = test-ot-tags

--- a/sourcefiles/pango.modules
+++ b/sourcefiles/pango.modules
@@ -3,21 +3,16 @@
 #
 # ModulesPath = ${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules
 #
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-arabic-fc${PANGO_SO_EXTENSION} ArabicScriptEngineFc PangoEngineShape PangoRenderFc arabic:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-basic-fc${PANGO_SO_EXTENSION} BasicScriptEngineFc PangoEngineShape PangoRenderFc armenian:* bopomofo:* cherokee:* coptic:* cyrillic:* deseret:* ethiopic:* georgian:* gothic:* greek:* han:* hiragana:* katakana:* latin:* ogham:* old-italic:* runic:* canadian-aboriginal:* yi:* braille:* cypriot:* limbu:* osmanya:* shavian:* linear-b:* ugaritic:* common:
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-hangul-fc${PANGO_SO_EXTENSION} HangulScriptEngineFc PangoEngineShape PangoRenderFc hangul:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-hebrew-fc${PANGO_SO_EXTENSION} HebrewScriptEngineFc PangoEngineShape PangoRenderFc hebrew:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} devaScriptEngineFc PangoEngineShape PangoRenderFc devanagari:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} bengScriptEngineFc PangoEngineShape PangoRenderFc bengali:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} guruScriptEngineFc PangoEngineShape PangoRenderFc gurmukhi:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} gujrScriptEngineFc PangoEngineShape PangoRenderFc gujarati:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} oryaScriptEngineFc PangoEngineShape PangoRenderFc oriya:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} tamlScriptEngineFc PangoEngineShape PangoRenderFc tamil:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} teluScriptEngineFc PangoEngineShape PangoRenderFc telugu:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} kndaScriptEngineFc PangoEngineShape PangoRenderFc kannada:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} mlymScriptEngineFc PangoEngineShape PangoRenderFc malayalam:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-fc${PANGO_SO_EXTENSION} sinhScriptEngineFc PangoEngineShape PangoRenderFc sinhala:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-khmer-fc${PANGO_SO_EXTENSION} KhmerScriptEngineFc PangoEngineShape PangoRenderFc khmer:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-syriac-fc${PANGO_SO_EXTENSION} SyriacScriptEngineFc PangoEngineShape PangoRenderFc syriac:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-thai-fc${PANGO_SO_EXTENSION} ThaiScriptEngineFc PangoEngineShape PangoRenderFc thai:* lao:*
-${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-tibetan-fc${PANGO_SO_EXTENSION} TibetanScriptEngineFc PangoEngineShape PangoRenderFc tibetan:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-arabic-lang${PANGO_SO_EXTENSION} ArabicScriptEngineLang PangoEngineLang PangoRenderNone arabic:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-basic-fc${PANGO_SO_EXTENSION} BasicScriptEngineFc PangoEngineShape PangoRenderFc common:
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} devaIndicScriptEngineLang PangoEngineLang PangoRenderNone devanagari:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} bengIndicScriptEngineLang PangoEngineLang PangoRenderNone bengali:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} guruIndicScriptEngineLang PangoEngineLang PangoRenderNone gurmukhi:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} gujrIndicScriptEngineLang PangoEngineLang PangoRenderNone gujarati:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} oryaIndicScriptEngineLang PangoEngineLang PangoRenderNone oriya:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} tamlIndicScriptEngineLang PangoEngineLang PangoRenderNone tamil:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} teluIndicScriptEngineLang PangoEngineLang PangoRenderNone telugu:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} kndaIndicScriptEngineLang PangoEngineLang PangoRenderNone kannada:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} mlymIndicScriptEngineLang PangoEngineLang PangoRenderNone malayalam:*
+${PANGO_PREFIX}/lib/pango/${PANGO_MODULE_VERSION}/modules/pango-indic-lang${PANGO_SO_EXTENSION} sinhIndicScriptEngineLang PangoEngineLang PangoRenderNone sinhala:*
+


### PR DESCRIPTION
Issue 4587
http://lists.gnu.org/archive/html/lilypond-devel/2015-08/msg00324.html

LilyPond 2.19.26 regtests, font-family-override.ly sans font problem will be solved by this patch.
Would you merge it and update local work tree?