### PR TITLE
Fix linux-64::libffi

### DIFF
--- a/gub/specs/libffi.py
+++ b/gub/specs/libffi.py
@@ -16,6 +16,12 @@ class Libffi (target.AutoBuild):
         self.system ('cd %(install_prefix)s && mv lib/libffi-3.2.1/include .')
         self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.2.1')
 
+class Libffi__linux__64 (Libffi):
+    # For using /usr/lib instead of /usr/lib64
+    patches = Libffi.patches + [
+        'libffi-3.2.1-linux-64-libdir.patch',
+    ]
+
 class Libffi__darwin__x86 (Libffi):
     # darwin-x86 can not compile libffi 3.1, 3.2.1.
     source = 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'

--- a/gub/specs/pango.py
+++ b/gub/specs/pango.py
@@ -1,32 +1,10 @@
-import re
-#
 from gub import misc
-from gub import loggedos
 from gub import target
 
-pango_module_version_regexes = [
-    (r'^1\.14', '1.5.0'),
-    (r'^1\.20', '1.6.0'),
-    (r'^1\.22', '1.6.0'),
-    (r'^1\.24', '1.6.0'),
-    (r'^1\.26', '1.6.0'),
-    (r'^1\.27', '1.6.0'),
-    (r'^1\.28', '1.6.0'),
-    (r'^1\.29', '1.6.0'),
-    (r'^1\.30', '1.6.0'),
-    (r'^1\.31', '1.8.0'),
-    (r'^1\.32', '1.8.0'),
-    (r'^1\.33', '1.8.0'),
-    (r'^1\.34', '1.8.0'),
-    (r'^1\.35', '1.8.0'),
-    (r'^1\.36', '1.8.0'),
-    ]
-
 class Pango (target.AutoBuild):
-    source = 'http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-1.36.8.tar.xz'
+    source = 'http://ftp.gnome.org/pub/GNOME/sources/pango/1.38/pango-1.38.1.tar.xz'
     patches = [
-        'pango-1.36.8-substitute-env.patch',
-        'pango-1.36.8-test-without-cairo.patch',
+        'pango-1.37.3-test-without-cairo.patch',
     ]
     dependencies = [
             'tools::glib', 
@@ -42,47 +20,3 @@ class Pango (target.AutoBuild):
                 + misc.join_lines ('''
 --without-cairo
 '''))
-    def module_version (self):
-        result = None
-        version = self.version()
-        for regex, candidate in pango_module_version_regexes:
-            if re.match(regex, version):
-                result = candidate
-                break
-        assert result
-        return result
-    def install (self):
-        target.AutoBuild.install (self)
-        self.create_config_files ()
-        self.fix_config_files ()
-    def create_config_files (self, prefix='/usr'):
-        pango_module_version = self.module_version ()
-        etc = self.expand ('%(install_root)s/%(prefix)s/etc/pango', locals ())
-        self.dump ('''[Pango]
-ModuleFiles = $PANGO_PREFIX/etc/pango/pango.modules
-ModulesPath = $PANGO_PREFIX/lib/pango/%(pango_module_version)s/modules
-''' % locals (), etc + '/pangorc')
-        self.dump ('''
-setfile PANGO_RC_FILE=$INSTALLER_PREFIX/etc/pango/pangorc
-setdir PANGO_PREFIX=$INSTALLER_PREFIX/
-set PANGO_MODULE_VERSION=%(pango_module_version)s
-''', '%(install_prefix)s/etc/relocate/pango.reloc', env=locals ())
-        self.copy ('%(sourcefiledir)s/pango.modules', etc)
-    def fix_config_files (self, prefix='/usr'):
-        etc = self.expand ('%(install_root)s/%(prefix)s/etc/pango', locals ())
-        self.system ('mkdir -p %(etc)s' , locals ())
-        def fix_prefix (logger, file_name):
-            loggedos.file_sub (logger, [('/' + prefix + '/', '$PANGO_PREFIX/')],
-                               file_name)
-        self.map_locate (fix_prefix, etc, '*')
-
-class Pango__freebsd (Pango):
-    dependencies = Pango.dependencies + ['libiconv-devel']
-
-class Pango__darwin (Pango):
-    def install (self):
-        Pango.install (self)                
-        # FIXME: PANGO needs .so, NOT .dylib?
-        self.dump ('''
-set PANGO_SO_EXTENSION=.so
-''', '%(install_prefix)s/etc/relocate/pango.reloc', env=locals (), mode='a')

--- a/patches/libffi-3.2.1-linux-64-libdir.patch
+++ b/patches/libffi-3.2.1-linux-64-libdir.patch
@@ -1,0 +1,14 @@
+--- libffi-3.2.1/configure.org	2014-11-12 20:59:57.000000000 +0900
++++ libffi-3.2.1/configure	2015-11-23 23:52:04.472673700 +0900
+@@ -18725,11 +18725,6 @@
+     toolexecdir="${libdir}"/gcc-lib/'$(target_alias)'
+     toolexeclibdir="${libdir}"
+   fi
+-  multi_os_directory=`$CC $CFLAGS -print-multi-os-directory`
+-  case $multi_os_directory in
+-    .) ;; # Avoid trailing /.
+-    ../*) toolexeclibdir=$toolexeclibdir/$multi_os_directory ;;
+-  esac
+ 
+ else
+   toolexeclibdir="${libdir}"

--- a/patches/pango-1.37.3-test-without-cairo.patch
+++ b/patches/pango-1.37.3-test-without-cairo.patch
@@ -1,0 +1,14 @@
+--- pango-1.37.3/tests/Makefile.in.org	2015-08-15 12:25:15.000000000 +0900
++++ pango-1.37.3/tests/Makefile.in	2015-08-29 15:16:49.975856800 +0900
+@@ -94,9 +94,8 @@
+ @HAVE_WIN32_TRUE@am__append_3 = -DHAVE_WIN32
+ @CROSS_COMPILING_FALSE@TESTS = $(check_PROGRAMS)
+ check_PROGRAMS = testboundaries$(EXEEXT) testboundaries_ucd$(EXEEXT) \
+-	testcolor$(EXEEXT) testscript$(EXEEXT) markup-parse$(EXEEXT) \
+-	test-layout$(EXEEXT) test-font$(EXEEXT) \
+-	testattributes$(EXEEXT) $(am__EXEEXT_1) $(am__EXEEXT_2) \
++	testcolor$(EXEEXT) testscript$(EXEEXT) \
++	$(am__EXEEXT_1) $(am__EXEEXT_2) \
+ 	$(am__EXEEXT_3)
+ @HAVE_CAIRO_TRUE@am__append_4 = testiter test-pangocairo-threads
+ @HAVE_FREETYPE_TRUE@am__append_5 = test-ot-tags


### PR DESCRIPTION
Issue 4669
http://sourceforge.net/p/testlilyissues/issues/4669/

On linux-64, libffi is on usr/lib64.
However, libffi.so.6 should be on usr/lib instead of usr/lib64.
This patch will solve this issue.

Would you merge it and try following command before next 2.19.33 `make lilypond'?
```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```