### PR TITLE
replace lilypond.org/download with lilypond.org/downloads

### DIFF
--- a/README
+++ b/README
@@ -337,7 +337,7 @@ gub/specs/hello.py
     from gub import target
 
     class Hello (target.AutoBuild):
-        source = 'http://lilypond.org/download/gub-sources/hello-1.0.tar.gz'
+        source = 'http://lilypond.org/downloads/gub-sources/hello-1.0.tar.gz'
 
 
 build it for mingw by doing

--- a/gub/mirrors.py
+++ b/gub/mirrors.py
@@ -27,8 +27,8 @@ freetype = 'http://download.savannah.gnu.org/releases/freetype/%(name)s-%(versio
 
 fontconfig = 'http://www.fontconfig.org/release/%(name)s-%(version)s.tar.%(format)s'
 
-lilypondorg = 'http://lilypond.org/download/gub-sources/%(name)s-%(version)s.tar.%(format)s'
-lilypondorg_deb = 'http://lilypond.org/download/gub-sources/%(name)s_%(version)s_%%(package_arch)s.%(format)s'
+lilypondorg = 'http://lilypond.org/downloads/gub-sources/%(name)s-%(version)s.tar.%(format)s'
+lilypondorg_deb = 'http://lilypond.org/downloads/gub-sources/%(name)s_%(version)s_%%(package_arch)s.%(format)s'
 
 jantien = 'http://www.xs4all.nl/~jantien/%(name)s-%(version)s.tar.%(format)s'
 

--- a/gub/misc.py
+++ b/gub/misc.py
@@ -313,7 +313,7 @@ def download_url (original_url, dest_dir,
                   dest_name='',
                   local=[],
                   cache=[os.environ.get ('GUB_DOWNLOAD_CACHE', '')],
-                  fallback=['http://lilypond.org/download/gub-sources'],
+                  fallback=['http://lilypond.org/downloads/gub-sources'],
                   progress=sys.stderr.write):
 
     assert type (local) == list

--- a/gub/sources.py
+++ b/gub/sources.py
@@ -16,8 +16,8 @@ from gub import mirrors
 gnu = 'http://ftp.gnu.org/pub/gnu'
 nongnu = 'http://download.savannah.nongnu.org/releases'
 sf = 'http://surfnet.dl.sourceforge.net/sourceforge'
-gub = 'http://lilypond.org/download/gub-sources'
-lp = 'http://lilypond.org/download/sources'
+gub = 'http://lilypond.org/downloads/gub-sources'
+lp = 'http://lilypond.org/downloads/sources'
 freedesktop = '.freedesktop.org/releases'
 
 ltool = mirrors.gnu % { 'name': 'libtool', 'version': '1.5.22', 'format': 'gz'}

--- a/gub/specs/boost.py
+++ b/gub/specs/boost.py
@@ -84,7 +84,7 @@ class UGLYFIXBoost__mingw (Boost):
 '''
     def __init__ (self, settings, source):
         Boost.__init__ (self, settings, source)
-        self.function_source = repository.get_repository_proxy (self.settings.downloads, 'http://lilypond.org/download/gub-sources/boost-function/boost-function-1.34.1.tar.gz?strip=0')
+        self.function_source = repository.get_repository_proxy (self.settings.downloads, 'http://lilypond.org/downloads/gub-sources/boost-function/boost-function-1.34.1.tar.gz?strip=0')
     def connect_command_runner (self, runner):
         printf ('FIXME: deferred workaround: should support multiple sources')
         if (runner):

--- a/gub/specs/cygwin/lilypond.py
+++ b/gub/specs/cygwin/lilypond.py
@@ -9,7 +9,7 @@ class LilyPond (lilypond.LilyPond):
 LilyPond lets you create music notation.  It produces beautiful
 sheet music from a high-level description file.'''
     subpackage_names = ['doc', '']
-    source = 'http://lilypond.org/download/source/v2.14/lilypond-2.14.1.tar.gz'
+    source = 'http://lilypond.org/downloads/source/v2.14/lilypond-2.14.1.tar.gz'
 #    source = 'git://git.sv.gnu.org/lilypond.git'
     dependencies = gup.gub_to_distro_deps (lilypond.LilyPond.dependencies,
                                            cygwin.gub_to_distro_dict) + [

--- a/gub/specs/darwin/darwin-sdk.py
+++ b/gub/specs/darwin/darwin-sdk.py
@@ -1,7 +1,7 @@
 from gub import build
 
 class Darwin_sdk (build.SdkBuild):
-    source = 'http://lilypond.org/download/gub-sources/darwin8-sdk/darwin8-sdk-0.4.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/darwin8-sdk/darwin8-sdk-0.4.tar.gz'
     def patch (self):
         self.system ('''
 rm %(srcdir)s/usr/lib/libgcc*

--- a/gub/specs/freebsd-runtime.py
+++ b/gub/specs/freebsd-runtime.py
@@ -1,7 +1,7 @@
 from gub import build
 
 class Freebsd_runtime (build.BinaryBuild, build.SdkBuild):
-    source = 'http://lilypond.org/download/gub-sources/freebsd-runtime/freebsd-runtime-6.2-1.%(package_arch)s.tar.gz&strip=0'
+    source = 'http://lilypond.org/downloads/gub-sources/freebsd-runtime/freebsd-runtime-6.2-1.%(package_arch)s.tar.gz&strip=0'
     def untar (self):
         build.BinaryBuild.untar (self)
         self.system ('''
@@ -12,4 +12,4 @@ rm -f %(srcdir)s%(prefix_dir)s/include/FlexLexer.h
 ''')
 
 class Freebsd_runtime__freebsd__64 (Freebsd_runtime):
-    source = 'http://lilypond.org/download/gub-sources/freebsd-runtime/freebsd-runtime-6.2-2.%(package_arch)s.tar.gz&strip=0'
+    source = 'http://lilypond.org/downloads/gub-sources/freebsd-runtime/freebsd-runtime-6.2-2.%(package_arch)s.tar.gz&strip=0'

--- a/gub/specs/glibc-core.py
+++ b/gub/specs/glibc-core.py
@@ -5,7 +5,7 @@ from gub.specs import glibc
 # Hmm? TARGET_CFLAGS=-O --> target.py
 
 class Glibc_core (glibc.Glibc):
-    source = 'http://lilypond.org/download/gub-sources/glibc/glibc-2.3-20070416.tar.bz2'
+    source = 'http://lilypond.org/downloads/gub-sources/glibc/glibc-2.3-20070416.tar.bz2'
     patches = glibc.Glibc.patches + [
         'glibc-2.3-core-install.patch',
         'glibc-2.3-core-libgcc.patch',

--- a/gub/specs/glibc.py
+++ b/gub/specs/glibc.py
@@ -40,7 +40,7 @@ to *not* look in /.
 # automagically depend on it, which is nice.
 # See cross.py:set_cross_dependencies ()
 class Glibc (target.AutoBuild, cross.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/glibc/glibc-2.3-20070416.tar.bz2'
+    source = 'http://lilypond.org/downloads/gub-sources/glibc/glibc-2.3-20070416.tar.bz2'
     patches = [
         'glibc-2.3-powerpc-initfini.patch',
         'glibc-2.3-powerpc-socket-weakalias.patch',

--- a/gub/specs/hello.py
+++ b/gub/specs/hello.py
@@ -1,4 +1,4 @@
 from gub import target
 
 class Hello (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/hello/hello-1.0.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/hello/hello-1.0.tar.gz'

--- a/gub/specs/libgnugetopt.py
+++ b/gub/specs/libgnugetopt.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libgnugetopt (target.MakeBuild):
-    source = 'http://lilypond.org/download/gub-sources/libgnugetopt/libgnugetopt-1.3.tar.bz2'
+    source = 'http://lilypond.org/downloads/gub-sources/libgnugetopt/libgnugetopt-1.3.tar.bz2'
     def patch (self):
         self.dump ('''
 prefix = %(prefix_dir)s

--- a/gub/specs/libwsock32.py
+++ b/gub/specs/libwsock32.py
@@ -17,7 +17,7 @@ class Libwsock32 (build.BinaryBuild):
 #    source = 'http://ftp.debian.org/debian/pool/main/w/wine/wine_0.9.25-2.1_i386.deb'
 # ugh, turns out this libwsock32.dll from wine is empty
 # which somehow means that linking works until you create an executable
-    source = 'http://lilypond.org/download/gub-sources/libwsock32-0.9.25.tar.gz&strip=0'
+    source = 'http://lilypond.org/downloads/gub-sources/libwsock32-0.9.25.tar.gz&strip=0'
     def __init__ (self, settings, source):
         build.BinaryBuild.__init__ (self, settings, source)
         source._version = '0.9.25'

--- a/gub/specs/licoli.py
+++ b/gub/specs/licoli.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Licoli (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/licoli-0.1.2.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/licoli-0.1.2.tar.gz'
     dependencies = ['tools::libtool']
     subpackage_names = ['']
 

--- a/gub/specs/lilypad.py
+++ b/gub/specs/lilypad.py
@@ -2,7 +2,7 @@ from gub import misc
 from gub import target
 
 class LilyPad (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/lilypad/lilypad-0.1.2.0-src.tar.bz2'
+    source = 'http://lilypond.org/downloads/gub-sources/lilypad/lilypad-0.1.2.0-src.tar.bz2'
     dependencies = [ 'tools::automake' ]
     destdir_install_broken = True
     license_files = ['']

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -11,7 +11,7 @@ from gub.specs import ghostscript
 
 VERSION='v2.14'
 def url (version=VERSION):
-    url = 'http://lilypond.org/download/source/%(version)s/' % locals ()
+    url = 'http://lilypond.org/downloads/source/%(version)s/' % locals ()
     raw_version_file = 'lilypond-%(version)s.index' % locals ()
     return misc.latest_url (url, 'lilypond', raw_version_file)
 

--- a/gub/specs/lilypondcairo.py
+++ b/gub/specs/lilypondcairo.py
@@ -6,7 +6,7 @@ from gub.specs import lilypond
 # in.  Hmm.
 
 class Lilypondcairo (lilypond.Lilypond):
-    source = 'http://lilypond.org/download/source/v2.13/lilypond-2.13.62.tar.gz'
+    source = 'http://lilypond.org/downloads/source/v2.13/lilypond-2.13.62.tar.gz'
     dependencies = [x.replace ('pango', 'pangocairo')
                     for x in lilypond.Lilypond.dependencies]
     patches = [

--- a/gub/specs/mingw-extras.py
+++ b/gub/specs/mingw-extras.py
@@ -1,6 +1,6 @@
 from gub import target
 
 class Mingw_extras (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/mingw-extras-0.1.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/mingw-extras-0.1.tar.gz'
     dependencies = ['tools::libtool']
     subpackage_names = ['']

--- a/gub/specs/netpbm.py
+++ b/gub/specs/netpbm.py
@@ -3,7 +3,7 @@ from gub import tools
 
 class Netpbm__tools (tools.AutoBuild):
     # source='svn:https://svn.sourceforge.net/svnroot/netpbm/stable&revision=172'
-    source='http://lilypond.org/download/gub-sources/netpbm-patched/netpbm-patched-10.35.tar.bz2'
+    source='http://lilypond.org/downloads/gub-sources/netpbm-patched/netpbm-patched-10.35.tar.bz2'
     patches = ['netpbm-10.35-glibc-2.10.1-name-conflict.patch']
     parallel_build_broken = True
     dependencies = ['flex', 'libjpeg', 'libpng', 'libtiff', 'zlib'] #libxml2? libx11-dev

--- a/gub/specs/osx-lilypad.py
+++ b/gub/specs/osx-lilypad.py
@@ -6,7 +6,7 @@ class Osx_lilypad (build.NullBuild):
 class Osx_lilypad__darwin__ppc (build.NullBuild):
     # yes, we really need the old version here
     # later versions were built on OSX 10.7, which doesn't have pcc support
-    source = 'http://lilypond.org/download/gub-sources/osx-lilypad-universal/osx-lilypad-universal-0.4.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/osx-lilypad-universal/osx-lilypad-universal-0.4.tar.gz'
 
 class Osx_lilypad__darwin__x86 (build.NullBuild):
-    source = 'http://lilypond.org/download/gub-sources/osx-lilypad-universal/osx-lilypad-universal-0.6.3.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/osx-lilypad-universal/osx-lilypad-universal-0.6.3.tar.gz'

--- a/gub/specs/patch.py
+++ b/gub/specs/patch.py
@@ -6,7 +6,7 @@ class Patch__tools (tools.AutoBuild):
 # ugh, openoffice the ooo-build flavour needs the latest patch with
 # additional [SUSE] patches to not barf on all CRLF problems.
 # Taken from the Ibex: apt-get --download source patch
-    source = 'http://lilypond.org/download/gub-sources/patch/patch-2.5.9-5.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/patch/patch-2.5.9-5.tar.gz'
     configure_variables = ''
     destdir_install_broken = True
     def configure (self):

--- a/gub/specs/regex.py
+++ b/gub/specs/regex.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Regex (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/regex/regex-2.3.90-1.tar.bz2'
+    source = 'http://lilypond.org/downloads/gub-sources/regex/regex-2.3.90-1.tar.bz2'
     dependencies = ['tools::libtool']

--- a/gub/specs/tcltk.py
+++ b/gub/specs/tcltk.py
@@ -2,7 +2,7 @@ from gub import context
 from gub import target
  
 class Tcltk (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/tcltk-8.4.14.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/tcltk-8.4.14.tar.gz'
     parallel_build_broken = True
     license_files = ['%(srcdir)s/tcl/license.terms']
     def configure (self):

--- a/gub/specs/texlive.py
+++ b/gub/specs/texlive.py
@@ -32,7 +32,7 @@ TeX, as well as the documentation accompanying the included software
 packages.'''
 
 #    source = texlive_svn + '&branch=trunk&branchmodule=Build/source&revision=HEAD'
-    source = 'http://lilypond.org/download/gub-sources/texlive/texlive-15644.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/texlive/texlive-15644.tar.gz'
     config_cache_flag_broken = True
     parallel_build_broken = True
     dependencies = [

--- a/gub/versiondb.py
+++ b/gub/versiondb.py
@@ -151,7 +151,7 @@ Inspect lilypond.org download area, and write pickle of all version numbers.
 
     p.add_option ('--url', action='store',
                   dest='url',
-                  default='http://lilypond.org/download/',
+                  default='http://lilypond.org/downloads/',
                   help='download url')
 
     p.add_option ('--download', action='store_true',

--- a/sourcefiles/lilypond-sharhead.sh
+++ b/sourcefiles/lilypond-sharhead.sh
@@ -291,7 +291,7 @@ tail -c+%(header_length)012d "$0" | tar -C "${prefix}" %(_z)s -xf -
 
 documentation="http://%(name)s.org/doc"
 
-mirror="http://lilypond.org/download"
+mirror="http://lilypond.org/downloads"
 doc_url_base="$mirror/binaries/documentation"
 if test "$doc" = yes; then
     documentation="file://${prefix}/usr/share/doc/lilypond/html/index.html

--- a/sourcefiles/lilypond.README
+++ b/sourcefiles/lilypond.README
@@ -54,7 +54,7 @@ Canonical homepage:
   http:/lilypond.org
 
 Canonical download:
-  http://lilypond.org/download
+  http://lilypond.org/downloads
   
 License:
   GNU GPL version 2

--- a/sourcefiles/sharhead.sh
+++ b/sourcefiles/sharhead.sh
@@ -279,7 +279,7 @@ tail -c+%(header_length)012d "$0" | tar -C "${prefix}" %(_z)s -xf -
 
 documentation="http://%(name)s.org/doc"
 
-##lily##mirror="http://lilypond.org/download"
+##lily##mirror="http://lilypond.org/downloads"
 ##lily##doc_url_base="$mirror/binaries/documentation"
 ##lily##if test "$doc" = yes; then
 ##lily##    documentation="file://${prefix}/usr/share/doc/lilypond/html/index.html

--- a/web/basics.html
+++ b/web/basics.html
@@ -266,7 +266,7 @@ target/tools/packages/bison.checksum
     <blockquote><pre>from gub import target
 
 class Hello (target.AutoBuild):
-    source = 'http://lilypond.org/download/gub-sources/hello-1.0.tar.gz'
+    source = 'http://lilypond.org/downloads/gub-sources/hello-1.0.tar.gz'
     </pre></blockquote>
 
     build it for mingw by doing

--- a/web/history.html
+++ b/web/history.html
@@ -35,7 +35,7 @@
       To get
       <a href="http://web.ncf.ca/bf250/rpm.html">a feel</a>
       for the times, this was
-      <a href="http://lilypond.org/download/source/v1.1/">LilyPond-1.1.47</a>,
+      <a href="http://lilypond.org/downloads/source/v1.1/">LilyPond-1.1.47</a>,
       requiring Egcs 1.1, Python 1.5, Guile 1.3, discussing on
       help-gnu-music@gnu.org.
 


### PR DESCRIPTION
lilypond.org/download should serve the website download page
through language negotiation:
https://sourceforge.net/p/testlilyissues/issues/4833/