### PR TITLE
Update FreeType to 2.6.3 etc.

### DIFF
--- a/gub/repository.py
+++ b/gub/repository.py
@@ -675,7 +675,7 @@ fatal: The remote end hung up unexpectedly
                 printf ('GIT: FIXME: shallow branching broken? -- getting *whole* history...')
                 self.git ('clone --bare %(source)s %(dir)s' % locals (), dir='.')
         if self.branch and not (self.revision and self.is_downloaded ()):
-            self.git ('fetch %(source)s %(branch)s:refs/heads/%(url_host)s/%(url_dir)s%(branch)s' % self.__dict__)
+            self.git ('fetch %(source)s %(branch)s:refs/heads/%(url_host)s%(url_dir)s/%(branch)s' % self.__dict__)
         self.checksums = {}
         self.post_download_hook ()
     def get_ref (self):

--- a/gub/repository.py
+++ b/gub/repository.py
@@ -606,8 +606,7 @@ cd %(dir_slash_vcs)s && mv *bz2 *deb *gz *zip .. || :
         # We cannot do a shallow download if we're not tracking
         # we have to get at least enough history to include the
         # fixed committish ... :-)
-        #no shallow# self.shallow = self.is_tracking ()
-        self.shallow = False
+        self.shallow = self.is_tracking ()
         assert self.url_host
         assert self.url_dir
     def version (self):
@@ -663,16 +662,10 @@ cd %(dir_slash_vcs)s && mv *bz2 *deb *gz *zip .. || :
         if not os.path.isdir (os.path.join (self.dir, 'refs')):
             source = self.source
             dir = self.dir
-            ### AARGH, GIT forces us to download the full history? WTF?
-            '''invoking cd /home/janneke/vc/gub/downloads/ghostscript && git clone --depth 10 -l -s /home/janneke/vc/gub/downloads/ghostscript /home/janneke/vc/gub/target/mingw/src/ghostscript-0.0
-Initialized empty Git repository in /home/janneke/vc/gub/target/mingw/src/ghostscript-0.0/.git/
-fatal: attempt to fetch/clone from a shallow repository
-fatal: The remote end hung up unexpectedly
-'''
             if self.shallow:
                 self.git ('clone --depth 10 --bare %(source)s %(dir)s' % locals (), dir='.')
             else:
-                printf ('GIT: FIXME: shallow branching broken? -- getting *whole* history...')
+                printf ('getting *whole* history...')
                 self.git ('clone --bare %(source)s %(dir)s' % locals (), dir='.')
         if self.branch and not (self.revision and self.is_downloaded ()):
             self.git ('fetch %(source)s %(branch)s:refs/heads/%(url_host)s%(url_dir)s/%(branch)s' % self.__dict__)

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -21,13 +21,9 @@ does not depend on the X Window System.  It is designed to locate
 fonts within the system and select them according to requirements
 specified by applications.'''
 
-    source = 'http://fontconfig.org/release/fontconfig-2.11.1.tar.bz2'
+    source = 'http://fontconfig.org/release/fontconfig-2.11.95.tar.bz2'
     patches = [
         'fontconfig-2.11.1-conf-relative-symlink.patch',
-        # This patch will be unnecessary from fontconfig-2.11.91.
-        'fontconfig-2.11.1-texgyre-aliases.patch',
-        # This patch will be unnecessary from fontconfig-2.11.91.
-        'fontconfig-2.11.1-new-urw-aliases.patch',
     ]
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
     dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']

--- a/gub/specs/freetype.py
+++ b/gub/specs/freetype.py
@@ -10,8 +10,28 @@ libraries, display servers, font conversion tools, text image generation
 tools, and many other products as well.'''
 
     source = 'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.3.tar.bz2'
-    dependencies = ['libtool-devel', 'zlib-devel', 'tools::bzip2']
+    dependencies = [
+        'libtool-devel',
+        'zlib-devel',
+        'tools::bzip2'
+    ]
     subpackage_names = ['devel', '']
+    configure_flags = (target.AutoBuild.configure_flags
+                       + ' --without-png'
+                       + ' --without-harfbuzz'
+    )
 
 class Freetype__tools (tools.AutoBuild, Freetype):
-    dependencies = ['libtool', 'zlib']
+    dependencies = [
+        'libtool',
+        'zlib',
+        'libpng',
+        'bzip2',
+    ]
+    configure_command = (
+        ''' LIBPNG_CFLAGS='-I%(tools_prefix)s/include/libpng12' ''' +
+        ''' LIBPNG_LIBS='-I%(tools_prefix)s/lib -lpng12' ''' +
+        tools.AutoBuild.configure_command)
+    configure_flags = (tools.AutoBuild.configure_flags
+                       + ' --without-harfbuzz'
+    )

--- a/gub/specs/freetype.py
+++ b/gub/specs/freetype.py
@@ -1,5 +1,3 @@
-from gub import build
-from gub import misc
 from gub import target
 from gub import tools
 
@@ -11,56 +9,9 @@ high-quality output (glyph images). It can be used in graphics
 libraries, display servers, font conversion tools, text image generation
 tools, and many other products as well.'''
 
-    source = 'http://download.savannah.nongnu.org/releases/freetype/freetype-2.4.12.tar.gz&name=freetype'
-    def __init__ (self, settings, source):
-        target.AutoBuild.__init__ (self, settings, source)
-        # Freetype stats /sbin, /usr/sbin and /hurd to determine if
-        # build system is unix??
-        # build.append_dict (self, {'LIBRESTRICT_ALLOW': '/sbin:/usr/sbin:/hurd'})
-        if 'stat' in misc.librestrict ():
-            build.add_dict (self, {'LIBRESTRICT_ALLOW': '/sbin:/usr/sbin:/hurd:${LIBRESTRICT_ALLOW-/foo}'})
-    license_files = ['%(srcdir)s/docs/LICENSE.TXT']
-    dependencies = ['libtool-devel', 'zlib-devel', 'tools::autoconf']
+    source = 'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.3.tar.bz2'
+    dependencies = ['libtool-devel', 'zlib-devel', 'tools::bzip2']
     subpackage_names = ['devel', '']
-    def configure (self):
-#                self.autoupdate (autodir=os.path.join (self.srcdir (),
-#                                                       'builds/unix'))
-        self.system ('''
-        rm -f %(srcdir)s/builds/unix/{unix-def.mk,unix-cc.mk,ftconfig.h,freetype-config,freetype2.pc,config.status,config.log}
-''')
-        target.AutoBuild.configure (self)
-        self.file_sub ([('^LIBTOOL=.*', 'LIBTOOL=%(builddir)s/libtool --tag=CXX')], '%(builddir)s/Makefile')
-    def munge_ft_config (self, file):
-        self.file_sub ([('\nprefix=[^\n]+\n',
-                         '\nlocal_prefix=yes\nprefix=%(system_prefix)s\n'),
-                        ('\nhardcode_libdir_flag_spec=.*', '\nhardcode_libdir_flag_spec=')],
-                       file, must_succeed=True)
-
-    def install (self):
-        target.AutoBuild.install (self)
-        # FIXME: this is broken.  for a sane target development package,
-        # we want /usr/bin/freetype-config must survive.
-        # While cross building, we create an  <toolprefix>-freetype-config
-        # and prefer that.
-        self.system ('mkdir -p %(install_prefix)s%(cross_dir)s/bin/')
-        self.system ('mv %(install_prefix)s/bin/freetype-config %(install_prefix)s%(cross_dir)s/bin/freetype-config')
-        self.munge_ft_config ('%(install_prefix)s%(cross_dir)s/bin/freetype-config')
-
-class Freetype__mingw (Freetype):
-    def xxconfigure (self):
-        Freetype.configure (self)
-        self.dump ('''
-# libtool will not build dll if -no-undefined flag is not present
-LDFLAGS:=$(LDFLAGS) -no-undefined
-''',
-             '%(builddir)s/Makefile',
-             mode='a')
 
 class Freetype__tools (tools.AutoBuild, Freetype):
     dependencies = ['libtool', 'zlib']
-    # FIXME, mi-urg?
-    license_files = Freetype.license_files
-    def install (self):
-        tools.AutoBuild.install (self)
-        #self.munge_ft_config ('%(install_root)s/%(tools_prefix)s/bin/.freetype-config')
-        self.munge_ft_config ('%(install_root)s/%(tools_prefix)s/bin/freetype-config')

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -88,7 +88,6 @@ models.'''
     dependencies = [
         'freetype-devel',
         'libjpeg-devel',
-        'libpng-devel',
         'libtiff-runtime',
         'tools::pkg-config',
         ]
@@ -335,7 +334,6 @@ class Ghostscript__tools (tools.AutoBuild, Ghostscript_static):
     dependencies = [
         'freetype-devel',
         'libjpeg-devel',
-        'libpng-devel',
         'libtiff-devel',
         ]
     configure_flags = (tools.AutoBuild.configure_flags

--- a/gub/specs/git.py
+++ b/gub/specs/git.py
@@ -2,56 +2,15 @@ from gub import target
 from gub import tools
 
 class Git (target.AutoBuild):
-    ## source = 'http://kernel.org/pub/software/scm/git/git-1.6.4.4.tar.gz'
-    source = 'http://git-core.googlecode.com/files/git-1.7.7.tar.gz'
+    source = 'https://www.kernel.org/pub/software/scm/git/git-2.8.3.tar.xz'
     srcdir_build_broken = True
     subpackage_names = ['']
-    dependencies = ['zlib-devel']
-    config_cache_overrides = target.AutoBuild.config_cache_overrides + '''
-ac_cv_c_c99_format=no
-ac_cv_fread_reads_directories=no
-ac_cv_snprintf_returns_bongus=yes
-'''
+    dependencies = ['zlib-devel', 'tools::xzutils']
     configure_flags = (tools.AutoBuild.configure_flags
                        + ' --without-openssl'
                        + ' --without-tcltk'
                        )
     make_flags = '''V=1 NO_PERL=NoThanks'''
-
-class Git__freebsd (Git):
-    dependencies = Git.dependencies + ['libiconv-devel', 'regex-devel']
-    make_flags = (Git.make_flags
-                  + ' CFLAGS="-O2 -Duintmax_t=unsigned -Dstrtoumax=strtoul"')
-
-class Git__mingw (Git):
-    dependencies = Git.dependencies + ['libiconv-devel', 'regex-devel', 'tcltk']
-    make_flags = (' uname_S=MINGW'
-                + ' V=1 '
-                ## we'll consider it if they clean up their act
-                + ' SCRIPT_PERL= '
-                + ' instdir_SQ=%(install_prefix)s/lib/ '
-                + ' SHELL_PATH=/bin/sh'
-                + ' PERL_PATH=/bin/perl')
-    compile_flags = ' template_dir=../share/git-core/templates/'
-    def __init__ (self, settings, source):
-        Git.__init__ (self, settings, source)
-        self.target_gcc_flags = ' -mms-bitfields '
-    def configure (self):
-        target.AutoBuild.configure (self)
-        self.file_sub ([('CFLAGS = -g',
-                         'CFLAGS = -I compat/ -g')],
-                       '%(builddir)s/config.mak.autogen')
-        self.file_sub ([('-lsocket',
-                         '-lwsock32'),
-                        ],
-                       '%(builddir)s/Makefile')
-        self.dump ('%(version)s-GUB', '%(builddir)s/version')
-    def install (self):
-        Git.install (self)
-        bat = r'''@echo off
-"@INSTDIR@\usr\bin\wish84.exe" "@INSTDIR@\usr\bin\gitk" %1 %2 %3 %4 %5 %6 %7 %8 %9
-'''.replace ('%','%%').replace ('\n','\r\n')
-        self.dump (bat, '%(install_prefix)s/bin/gitk.bat.in')
 
 class Git__tools (tools.AutoBuild, Git):
     dependencies = ['curl', 'expat', 'zlib']

--- a/gub/specs/harfbuzz.py
+++ b/gub/specs/harfbuzz.py
@@ -2,7 +2,7 @@ from gub import target
 from gub import tools
 
 class Harfbuzz (target.AutoBuild):
-    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.0.2.tar.bz2'
+    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.7.tar.bz2'
     dependencies = [
         'tools::bzip2',
         'freetype-devel',

--- a/gub/specs/imagemagick.py
+++ b/gub/specs/imagemagick.py
@@ -4,7 +4,7 @@ from gub import misc
 from gub import tools
 
 class ImageMagick__tools (tools.AutoBuild):
-    source = 'http://www.imagemagick.org/download/releases/ImageMagick-6.5.7-9.tar.gz'
+    source = 'http://www.imagemagick.org/download/releases/ImageMagick-6.5.7-9.tar.xz'
     dependencies = [
             'automake',
             'bzip2',
@@ -17,6 +17,7 @@ class ImageMagick__tools (tools.AutoBuild):
             'libtool',
             'perl',
             'zlib',
+            'tools::xzutils',
             ]
     configure_flags = (tools.AutoBuild.configure_flags
                 + misc.join_lines ('''

--- a/gub/specs/libpng.py
+++ b/gub/specs/libpng.py
@@ -2,8 +2,14 @@ from gub import target
 from gub import tools 
 
 class Libpng (target.AutoBuild):
-    source = 'http://sourceforge.net/projects/libpng/files/libpng12/1.2.53/libpng-1.2.53.tar.gz'
-    dependencies = ['zlib-devel', 'tools::autoconf', 'tools::automake', 'tools::libtool']
+    source = 'http://sourceforge.net/projects/libpng/files/libpng12/1.2.56/libpng-1.2.56.tar.xz'
+    dependencies = [
+        'zlib-devel',
+        'tools::autoconf',
+        'tools::automake',
+        'tools::libtool',
+        'tools::xzutils',
+    ]
     def name (self):
         return 'libpng'
     def patch (self):
@@ -21,6 +27,6 @@ class Libpng (target.AutoBuild):
                                         target.AutoBuild.compile_command)
     
 class Libpng__tools (tools.AutoBuild, Libpng):
-    dependencies = ['libtool']
+    dependencies = ['libtool', 'xzutils']
     def patch (self):
         Libpng.patch (self)

--- a/gub/specs/pango.py
+++ b/gub/specs/pango.py
@@ -2,7 +2,7 @@ from gub import misc
 from gub import target
 
 class Pango (target.AutoBuild):
-    source = 'http://ftp.gnome.org/pub/GNOME/sources/pango/1.38/pango-1.38.1.tar.xz'
+    source = 'http://ftp.gnome.org/pub/GNOME/sources/pango/1.40/pango-1.40.1.tar.xz'
     patches = [
         'pango-1.37.3-test-without-cairo.patch',
     ]


### PR DESCRIPTION
Issue 4876: The wrong font name is embedded by using some OTF / OTC fonts 
https://sourceforge.net/p/testlilyissues/issues/4876/

For avoiding wrong font name, this pull request updates FreeType and some libraries.

Would you merge it and try following command before next `make lilypond'?

```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```