### PR TITLE
Update texinfo to 6.1

### DIFF
--- a/gub/specs/texinfo.py
+++ b/gub/specs/texinfo.py
@@ -1,15 +1,5 @@
 from gub import tools
 
 class Texinfo__tools (tools.AutoBuild):
-    source = 'http://ftp.gnu.org/pub/gnu/texinfo/texinfo-4.13a.tar.gz'
-    patches = ['texinfo-4.13a-fix-bashism.patch']
-    def patch (self):
-        tools.AutoBuild.patch (self)
-        # Drop ncurses dependency
-        self.file_sub ([(' info ',' ')], '%(srcdir)s/Makefile.in')
-        # Avoid man rebuild
-        self.system('''
-touch %(srcdir)s/doc/texi2dvi.1
-touch %(srcdir)s/doc/texi2pdf.1
-touch %(srcdir)s/doc/pdftexi2dvi.1
-''')
+    source = 'http://ftp.gnu.org/pub/gnu/texinfo/texinfo-6.1.tar.xz'
+    dependencies = [ 'tools::xzutils' ]


### PR DESCRIPTION
This patch updates texinfo to 6.1.
In my GUB environment, the following commands are succeed.

```
$ bin/gub tools::texinfo
$ bin/gub linux-64::lilypond
$ bin/gub linux-64::lilypond-doc
```
