### PR TITLE
Fix librestrict C99 and update some libraries

### DIFF
--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -21,7 +21,7 @@ does not depend on the X Window System.  It is designed to locate
 fonts within the system and select them according to requirements
 specified by applications.'''
 
-    source = 'http://fontconfig.org/release/fontconfig-2.11.95.tar.bz2'
+    source = 'http://fontconfig.org/release/fontconfig-2.12.1.tar.bz2'
     patches = [
         'fontconfig-2.11.1-conf-relative-symlink.patch',
     ]

--- a/gub/specs/freetype.py
+++ b/gub/specs/freetype.py
@@ -9,7 +9,7 @@ high-quality output (glyph images). It can be used in graphics
 libraries, display servers, font conversion tools, text image generation
 tools, and many other products as well.'''
 
-    source = 'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.3.tar.bz2'
+    source = 'http://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2'
     dependencies = [
         'libtool-devel',
         'zlib-devel',

--- a/gub/specs/guile.py
+++ b/gub/specs/guile.py
@@ -225,6 +225,11 @@ LDFLAGS='-L%(system_prefix)s/lib %(rpath)s'
     compile_command = ('export LD_LIBRARY_PATH=%(builddir)s/libguile/.libs:%(system_prefix)s/lib:${LD_LIBRARY_PATH-/foe};'
                 + Guile.compile_command)
     def patch (self):
+        # Guile's texi files can not be compiled by texinfo-6.1.
+        self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
+                       '%(srcdir)s/doc/Makefile.am')
+        self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
+                       '%(srcdir)s/doc/Makefile.in')
         tools.AutoBuild.patch (self)
         #Guile.autopatch (self)
     def install (self):

--- a/gub/specs/harfbuzz.py
+++ b/gub/specs/harfbuzz.py
@@ -2,7 +2,7 @@ from gub import target
 from gub import tools
 
 class Harfbuzz (target.AutoBuild):
-    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.7.tar.bz2'
+    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.0.tar.bz2'
     dependencies = [
         'tools::bzip2',
         'freetype-devel',

--- a/gub/specs/libffi.py
+++ b/gub/specs/libffi.py
@@ -3,18 +3,12 @@ from gub import tools
 
 class Libffi (target.AutoBuild):
     source = 'ftp://sourceware.org/pub/libffi/libffi-3.2.1.tar.gz'
+    patches = [ 'libffi-3.2.1-includedir.patch', ]
     dependencies = [
         'tools::automake',
         'tools::libtool',
         'tools::pkg-config',
         ]
-    # huh?
-    install_flags = (target.AutoBuild.install_flags
-                     + """ includesdir='$(includedir)' """ )
-    def install (self):
-        target.AutoBuild.install (self)
-        self.system ('cd %(install_prefix)s && mv lib/libffi-3.2.1/include .')
-        self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.2.1')
 
 class Libffi__linux__64 (Libffi):
     # For using /usr/lib instead of /usr/lib64
@@ -25,10 +19,7 @@ class Libffi__linux__64 (Libffi):
 class Libffi__darwin__x86 (Libffi):
     # darwin-x86 can not compile libffi 3.1, 3.2.1.
     source = 'ftp://sourceware.org/pub/libffi/libffi-3.0.13.tar.gz'
-    def install (self):
-        target.AutoBuild.install (self)
-        self.system ('cd %(install_prefix)s && mv lib/libffi-3.0.13/include .')
-        self.system ('cd %(install_prefix)s && rm -rf lib/libffi-3.0.13')
+    patches = [ 'libffi-3.0.13-includedir.patch', ]
 
 class Libffi__tools (tools.AutoBuild, Libffi):
     pass

--- a/gub/specs/librestrict.py
+++ b/gub/specs/librestrict.py
@@ -3,7 +3,7 @@ from gub import tools
 from gub import misc
 
 class Librestrict_make__tools (tools.MakeBuild):
-    source = 'url://host/librestrict-1.9a.tar.gz'
+    source = 'url://host/librestrict-1.9b.tar.gz'
     def librestrict_flavours (self):
         return misc.librestrict ()
     def flavours (self):

--- a/librestrict/restrict.c
+++ b/librestrict/restrict.c
@@ -191,7 +191,7 @@ static void initialize (void) __attribute__ ((constructor));
 static
 void initialize (void)
 {
-  char *restrict;
+  char *restrict_string;
   char *verbosity_string = getenv ("LIBRESTRICT_VERBOSE");
   
   if (verbosity_string)
@@ -201,14 +201,14 @@ void initialize (void)
 	verbosity = 1;
     }
   executable_name = get_executable_name ();
-  restrict = get_allowed_prefix (executable_name);
-  if (restrict)
+  restrict_string = get_allowed_prefix (executable_name);
+  if (restrict_string)
     {
       char *allow = getenv ("LIBRESTRICT_ALLOW");
       if (verbosity > 1)
 	fprintf (stderr, "librestrict:warning:%s: allow: %s\n", __PRETTY_FUNCTION__, allow);
 
-      add_allowed_file (restrict);
+      add_allowed_file (restrict_string);
       if (allow)
         add_allowed_path (allow);
       add_allowed_file ("/tmp");

--- a/patches/libffi-3.0.13-includedir.patch
+++ b/patches/libffi-3.0.13-includedir.patch
@@ -1,0 +1,22 @@
+--- libffi-3.0.13/libffi.pc.in.org	2013-03-16 20:19:39.000000000 +0900
++++ libffi-3.0.13/libffi.pc.in	2016-08-09 19:34:04.668010300 +0900
+@@ -1,7 +1,7 @@
+ prefix=@prefix@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=@includedir@
+ 
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces
+--- libffi-3.0.13/include/Makefile.in.org	2013-03-18 07:36:21.000000000 +0900
++++ libffi-3.0.13/include/Makefile.in	2016-08-09 19:34:52.019126700 +0900
+@@ -250,7 +250,7 @@
+ AUTOMAKE_OPTIONS = foreign
+ DISTCLEANFILES = ffitarget.h
+ EXTRA_DIST = ffi.h.in ffi_common.h
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+ all: all-am
+ 

--- a/patches/libffi-3.2.1-includedir.patch
+++ b/patches/libffi-3.2.1-includedir.patch
@@ -1,0 +1,22 @@
+--- libffi-3.2.1/libffi.pc.in.org	2014-11-08 21:47:24.000000000 +0900
++++ libffi-3.2.1/libffi.pc.in	2016-08-09 19:27:53.897837500 +0900
+@@ -2,7 +2,7 @@
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ toolexeclibdir=@toolexeclibdir@
+-includedir=${libdir}/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includedir=@includedir@
+ 
+ Name: @PACKAGE_NAME@
+ Description: Library supporting Foreign Function Interfaces
+--- libffi-3.2.1/include/Makefile.in.org	2014-11-12 20:59:58.000000000 +0900
++++ libffi-3.2.1/include/Makefile.in	2016-08-09 19:26:57.718194900 +0900
+@@ -314,7 +314,7 @@
+ AUTOMAKE_OPTIONS = foreign
+ DISTCLEANFILES = ffitarget.h
+ EXTRA_DIST = ffi.h.in ffi_common.h
+-includesdir = $(libdir)/@PACKAGE_NAME@-@PACKAGE_VERSION@/include
++includesdir = $(includedir)
+ nodist_includes_HEADERS = ffi.h ffitarget.h
+ all: all-am
+ 


### PR DESCRIPTION
This pull request fixes librestrict C99 problem that is reported here.
http://lists.gnu.org/archive/html/lilypond-devel/2016-08/msg00045.html

And, this pull request fixes tools::guile texi compilation problem.
Also, some libraries update is contained.