### PR TITLE
Fix fontconfg cache failure on mac

### DIFF
--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -125,6 +125,9 @@ class Fontconfig__mingw (Fontconfig):
                    mode='a')
 
 class Fontconfig__darwin (Fontconfig):
+    patches = Fontconfig.patches + [
+        'fontconfig-2.12.1-mac.patch'
+    ]
     configure_flags = (Fontconfig.configure_flags
                          + ' --with-add-fonts=/Library/Fonts,/System/Library/Fonts ')
     def configure (self):

--- a/patches/fontconfig-2.12.1-mac.patch
+++ b/patches/fontconfig-2.12.1-mac.patch
@@ -1,0 +1,44 @@
+https://bugs.freedesktop.org/show_bug.cgi?id=97546
+Bug 97546 - fc-cache failure with /System/Library/Fonts
+
+https://bugs.freedesktop.org/attachment.cgi?id=126464
+proposed (1.24 KB, patch)
+2016-09-12 01:57 UTC, Akira TAGOH
+
+diff --git a/src/fccache.c b/src/fccache.c
+index 02ec301..7e4e600 100644
+--- a/src/fccache.c
++++ b/src/fccache.c
+@@ -640,6 +640,8 @@ FcCacheOffsetsValid (FcCache *cache)
+             FcPattern		*font = FcFontSetFont (fs, i);
+             FcPatternElt	*e;
+             FcValueListPtr	 l;
++	    ssize_t              c;
++	    char                *begin;
+ 
+             if ((char *) font < base ||
+                 (char *) font > end - sizeof (FcFontSet) ||
+@@ -653,11 +655,18 @@ FcCacheOffsetsValid (FcCache *cache)
+             if (e->values != 0 && !FcIsEncodedOffset(e->values))
+                 return FcFalse;
+ 
+-            for (j = font->num, l = FcPatternEltValues(e); j >= 0 && l; j--, l = FcValueListNext(l))
+-                if (l->next != NULL && !FcIsEncodedOffset(l->next))
+-                    break;
+-            if (j < 0)
+-                return FcFalse;
++	    for (j = 0; j < font->num; j++)
++	    {
++		begin = (char *)FcPatternEltValues(&e[j]);
++		c = (end - begin) / sizeof (FcValueList);
++		for (l = FcPatternEltValues(&e[j]); l; l = FcValueListNext(l))
++		{
++		    if ((char *) l < begin || (char *)l > end - sizeof (*l) ||
++			(l->next != NULL && !FcIsEncodedOffset(l->next)) ||
++			c-- <= 0)
++			return FcFalse;
++		}
++	    }
+         }
+     }
+ 


### PR DESCRIPTION
http://lists.gnu.org/archive/html/lilypond-devel/2016-09/msg00097.html
https://bugs.freedesktop.org/show_bug.cgi?id=97546

Would you merge it and try following command before next `make lilypond'?

```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```
