### PR TITLE
Ghostscript 9.20

### DIFF
--- a/gub/specs/cross/gcc.py
+++ b/gub/specs/cross/gcc.py
@@ -8,7 +8,7 @@ from gub import misc
 from gub.specs import gcc
 
 class Gcc (cross.AutoBuild):
-    source = 'http://ftp.gnu.org/pub/gnu/gcc/gcc-4.9.2/gcc-4.9.2.tar.bz2'
+    source = 'http://ftp.gnu.org/pub/gnu/gcc/gcc-4.9.4/gcc-4.9.4.tar.bz2'
     dependencies = [
         'cross/binutils',
         'system::gcc',

--- a/gub/specs/darwin/cross/gcc.py
+++ b/gub/specs/darwin/cross/gcc.py
@@ -60,9 +60,6 @@ class Gcc__darwin (cross_gcc.Gcc):
         self.rewire_gcc_libs ()
 
 class Gcc__darwin__ppc (Gcc__darwin):
-    patches = Gcc__darwin.patches + [
-        'gcc-4.9.2-darwin-powerpc.patch', # This patch will not be needed from gcc 4.9.3.
-    ]
     configure_flags = (Gcc__darwin.configure_flags
                        + ' --disable-libitm'
     )

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -24,6 +24,10 @@ specified by applications.'''
     source = 'http://fontconfig.org/release/fontconfig-2.12.1.tar.bz2'
     patches = [
         'fontconfig-2.11.1-conf-relative-symlink.patch',
+        # This patch will not be needed from fontconfig 2.12.2.
+        'fontconfig-2.12.1-fix-psfont-alias.patch',
+        # This patch will not be needed from fontconfig 2.12.2.
+        'fontconfig-2.12.1-urw-june-2016.patch',
     ]
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
     dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']

--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -2,13 +2,17 @@ from gub import tools
 from gub import build
 
 class Fonts_urw_core35 (build.BinaryBuild):
-    # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=c983ed400dc278dcf20bdff68252fad6d9db7af9
-    revision = 'c983ed400dc278dcf20bdff68252fad6d9db7af9'
+    # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=79bcdfb34fbce12b592cce389fa7a19da6b5b018
+    revision = '79bcdfb34fbce12b592cce389fa7a19da6b5b018'
     source = 'git://git.ghostscript.com/urw-core35-fonts.git&revision=' + revision
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/urw-core35')
+        self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/urw-core35')
         self.system ('cp %(srcdir)s/*.afm %(install_prefix)s/share/fonts/type1/urw-core35/')
-        self.system ('cp %(srcdir)s/*.pf? %(install_prefix)s/share/fonts/type1/urw-core35/')
+        self.system ('cp %(srcdir)s/*.t1 %(install_prefix)s/share/fonts/type1/urw-core35/')
+        self.system ('cp %(srcdir)s/*.ttf %(install_prefix)s/share/fonts/truetype/urw-core35/')
+        self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/urw-core35/')
     def package (self):
         build.AutoBuild.package (self)
 

--- a/gub/specs/freetype.py
+++ b/gub/specs/freetype.py
@@ -13,7 +13,8 @@ tools, and many other products as well.'''
     dependencies = [
         'libtool-devel',
         'zlib-devel',
-        'tools::bzip2'
+        'tools::bzip2',
+        'tools::pkg-config',
     ]
     subpackage_names = ['devel', '']
     configure_flags = (target.AutoBuild.configure_flags

--- a/gub/specs/freetype.py
+++ b/gub/specs/freetype.py
@@ -28,6 +28,7 @@ class Freetype__tools (tools.AutoBuild, Freetype):
         'zlib',
         'libpng',
         'bzip2',
+        'pkg-config',
     ]
     configure_command = (
         ''' LIBPNG_CFLAGS='-I%(tools_prefix)s/include/libpng12' ''' +

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -236,6 +236,7 @@ else:
 class Ghostscript__mingw (Ghostscript):
     exe = '.exe'
     patches = Ghostscript.patches + [
+        'ghostscript-9.20-mingw-unix-aux.patch',
         'ghostscript-9.15-windows-dxmain.patch'
     ]
     def __init__ (self, settings, source):
@@ -262,16 +263,6 @@ ac_cv_lib_pthread_pthread_create=no
                            '%(builddir)s/Makefile')
         self.file_sub ([('^(EXTRALIBS *=.*)', r'\1 -lwinspool -lcomdlg32 -lz')],
                        '%(builddir)s/Makefile')
-        self.file_sub ([('^unix__=.*', misc.join_lines ('''unix__=
-$(GLOBJ)gp_mswin.$(OBJ)
-$(GLOBJ)gp_wgetv.$(OBJ)
-$(GLOBJ)gp_stdia.$(OBJ)
-$(GLOBJ)gp_ntfs.$(OBJ)
-$(GLOBJ)gp_win32.$(OBJ)
-$(GLOBJ)gp_upapr.$(OBJ) 
-$(GLOBJ)gp_wutf8.$(OBJ)
-'''))],
-               '%(srcdir)s/base/unix-aux.mak')        
         self.dump ('''
 GLCCWIN=$(CC) $(CFLAGS) -I$(GLOBJDIR)
 PSCCWIN=$(CC) $(CFLAGS) -I$(GLOBJDIR)

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -55,7 +55,7 @@ models.'''
                 + ' docdir=%(prefix_dir)s/share/doc/ghostscript/doc '
                 + ' exdir=%(prefix_dir)s/share/doc/ghostscript/examples ')
     # Ghostscript's check for sys/time.h is buggy: it only looks in /usr/include.
-    make_flags = target.AutoBuild.make_flags + ' TARGET=%(target_os)s CFLAGS+="-DHAVE_SYS_TIME_H=1"'
+    make_flags = target.AutoBuild.make_flags + ' TARGET=%(target_os)s CFLAGS+="-DHAVE_SYS_TIME_H=1 -DHAVE_STDINT_H=1"'
     obj = 'obj'
     @staticmethod
     def static_version (self=False):

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -26,6 +26,7 @@ models.'''
         'ghostscript-9.15-windows-popen.patch',
         'ghostscript-9.20-windows-snprintf.patch',
         'ghostscript-9.20-windows-make.patch',
+        'ghostscript-9.20-mingw-struct-stat.patch',
         'ghostscript-9.20-linux-useunix98.patch',
        ]
     parallel_build_broken = True

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -25,6 +25,7 @@ models.'''
         'ghostscript-9.20-cygwin.patch',
         'ghostscript-9.15-windows-popen.patch',
         'ghostscript-9.20-windows-snprintf.patch',
+        'ghostscript-9.20-windows-make.patch',
         'ghostscript-9.20-linux-useunix98.patch',
        ]
     parallel_build_broken = True

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -294,6 +294,29 @@ class Ghostscript__freebsd (Ghostscript):
             self.file_sub ([('^(EXTRALIBS *=.*)(-ldl )', r'\1')],
                            '%(builddir)s/Makefile')
 
+class Ghostscript__freebsd__x86 (Ghostscript__freebsd):
+    # ***FIXME*** Ghostscript 9.20 for freebsd-x86 raises seg fault.
+    # So we use Ghostscript 9.15.
+    source = 'http://downloads.ghostscript.com/public/old-gs-releases/ghostscript-9.15.tar.gz'
+    patches = [
+        'ghostscript-9.15-make.patch',
+        'ghostscript-9.15-cygwin.patch',
+        'ghostscript-9.15-windows-popen.patch',
+        'ghostscript-9.15-windows-snprintf.patch',
+        'ghostscript-9.15-windows-make.patch',
+        'ghostscript-9.15-freebsd6.patch'
+       ]
+    @staticmethod
+    def static_version (self=False):
+        return misc.version_from_url (Ghostscript__freebsd__x86.source)
+    def __init__ (self, settings, source):
+        target.AutoBuild.__init__ (self, settings, source)
+        if (isinstance (source, repository.Repository)
+            and not isinstance (source, repository.TarBall)):
+            source.version = misc.bind_method (Ghostscript__freebsd__x86.version_from_VERSION, source)
+        else:
+            source.version = misc.bind_method (Ghostscript__freebsd__x86.static_version, source)
+
 class Ghostscript__darwin (Ghostscript):
     patches = Ghostscript.patches + [
         'ghostscript-9.15-Resource-directory.patch'

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -19,13 +19,12 @@ Supported printers include common dot-matrix, inkjet and laser
 models.'''
 
     exe = ''
-    source = 'http://downloads.ghostscript.com/public/old-gs-releases/ghostscript-9.15.tar.gz'
+    source = 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs920/ghostscript-9.20.tar.gz'
     patches = [
-        'ghostscript-9.15-make.patch',
-        'ghostscript-9.15-cygwin.patch',
+        'ghostscript-9.20-make.patch',
+        'ghostscript-9.20-cygwin.patch',
         'ghostscript-9.15-windows-popen.patch',
-        'ghostscript-9.15-windows-snprintf.patch',
-        'ghostscript-9.15-windows-make.patch',
+        'ghostscript-9.20-windows-snprintf.patch',
        ]
     parallel_build_broken = True
     # For --enable-compile-inits, see comment in compile()

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -18,11 +18,7 @@ PostScript files as graphics to be printed on non-PostScript printers.
 Supported printers include common dot-matrix, inkjet and laser
 models.'''
 
-    #source = 'svn:http://svn.ghostscript.com:8080/ghostscript&branch=trunk/gs&revision=7881'
-    # HEAD - need to load TTF fonts on fedora without crashing.
     exe = ''
-    revision = 'b35333cf3579e85725bd7d8d39eacc9640515eb8'
-    #source = 'git://git.infradead.org/ghostscript.git?branch=refs/remotes/git-svn&revision=' + revision
     source = 'http://downloads.ghostscript.com/public/old-gs-releases/ghostscript-9.15.tar.gz'
     patches = [
         'ghostscript-9.15-make.patch',

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -25,6 +25,7 @@ models.'''
         'ghostscript-9.20-cygwin.patch',
         'ghostscript-9.15-windows-popen.patch',
         'ghostscript-9.20-windows-snprintf.patch',
+        'ghostscript-9.20-linux-useunix98.patch',
        ]
     parallel_build_broken = True
     # For --enable-compile-inits, see comment in compile()

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -203,7 +203,7 @@ models.'''
         # obj/mkromfs is needed for --enable-compile-inits but depends on native -liconv.
         self.system ('''
 cd %(builddir)s && mkdir -p %(obj)s
-cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf%(exe)s %(obj)s/aux/echogs%(exe)s %(obj)s/aux/genarch%(exe)s %(obj)s/arch.h 
+cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf %(obj)s/aux/echogs %(obj)s/aux/genarch %(obj)s/arch.h
 ''')
         self.fixup_arch ()
         target.AutoBuild.compile (self)

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -21,7 +21,9 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-luximono',
                 'tools::fonts-ipafont',
                 'tools::fonts-gnufreefont',
-                'system::makeinfo',
+                'tools::texinfo',
+                'system::xetex',
+                'system::xelatex',
                 'system::zip',
                 ])
     make_flags = misc.join_lines ('''

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -1,3 +1,4 @@
+import os
 #
 from gub import context
 from gub import misc
@@ -26,6 +27,18 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'system::xelatex',
                 'system::zip',
                 ])
+    def stages (self):
+        return ['patch'] + lilypond.LilyPond_base.stages (self)
+    def patch (self):
+        # system::xetex uses system's shared libraries instead of GUB's ones.
+        if 'system::xetex' in self.dependencies:
+            self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
+                           '%(srcdir)s/scripts/build/xetex-with-options.sh')
+        # system::xelatex uses system's shared libraries instead of GUB's ones.
+        if 'system::xelatex' in self.dependencies:
+            self.file_sub ([('^exec xelatex ',
+                             'LD_LIBRARY_PATH= exec xelatex ')],
+                           '%(srcdir)s/scripts/build/xelatex-with-options.sh')
     make_flags = misc.join_lines ('''
 CROSS=no
 DOCUMENTATION=yes

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -36,6 +36,7 @@ sheet music from a high-level description file.'''
         'pango-devel',
         'python-devel',
         'tools::fonts-texgyre',
+        'tools::fonts-urw-core35',
 
         'tools::autoconf',
         'tools::bison',
@@ -62,6 +63,7 @@ sheet music from a high-level description file.'''
                        + ' --enable-rpath'
                        + ' --disable-documentation'
                        + ' --with-texgyre-dir=%(tools_prefix)s/share/fonts/opentype/texgyre'
+                       + ' --with-urwotf-dir=%(tools_prefix)s/share/fonts/opentype/urw-core35'
                        )
     make_flags = ' TARGET_PYTHON=/usr/bin/python'
 

--- a/gub/specs/texinfo.py
+++ b/gub/specs/texinfo.py
@@ -2,4 +2,4 @@ from gub import tools
 
 class Texinfo__tools (tools.AutoBuild):
     source = 'http://ftp.gnu.org/pub/gnu/texinfo/texinfo-6.1.tar.xz'
-    dependencies = [ 'tools::xzutils' ]
+    dependencies = [ 'tools::xzutils', 'tools::perl' ]

--- a/gub/specs/zlib.py
+++ b/gub/specs/zlib.py
@@ -8,7 +8,7 @@ class Zlib (target.AutoBuild):
     source = 'http://sourceforge.net/projects/libpng/files/zlib/1.2.3/zlib-1.2.3.tar.gz'
     patches = ['zlib-1.2.3.patch']
     srcdir_build_broken = True
-    dependencies = ['tools::autoconf']
+    dependencies = ['tools::autoconf', 'tools::pkg-config']
     make_flags = ' ARFLAGS=r'
     destdir_install_broken = True
     install_flags = ' install'
@@ -58,7 +58,7 @@ no shared lib: gcc-4.2.1 says
 
 class Zlib__tools (tools.AutoBuild, Zlib):
     srcdir_build_broken = True
-    dependencies = ['autoconf']
+    dependencies = ['autoconf', 'pkg-config']
     configure_command = Zlib.configure_command
     destdir_install_broken = True
     install_flags = ' install'

--- a/patches/fontconfig-2.12.1-fix-psfont-alias.patch
+++ b/patches/fontconfig-2.12.1-fix-psfont-alias.patch
@@ -1,0 +1,68 @@
+From 815cc98d6a7df142c8f1a9a2c1120650da278db0 Mon Sep 17 00:00:00 2001
+From: Masamichi Hosoda <trueroad@trueroad.jp>
+Date: Wed, 24 Aug 2016 21:27:32 +0900
+Subject: Fix PostScript font alias name
+
+`Helvetica Condensed' is not PostScript base 35 fonts.
+`Helvetica Narrow' is PostScript base 35 fonts.
+
+diff --git a/conf.d/30-metric-aliases.conf b/conf.d/30-metric-aliases.conf
+index cd1e924..e72bf7a 100644
+--- a/conf.d/30-metric-aliases.conf
++++ b/conf.d/30-metric-aliases.conf
+@@ -9,7 +9,7 @@ Alias similar/metric-compatible families from various sources:
+ PostScript fonts:       URW fonts:              GUST fonts:        Windows fonts:
+ ======================  ======================  =================  ==================
+ Helvetica               Nimbus Sans             TeX Gyre Heros
+-Helvetica Condensed     Nimbus Sans Narrow      TeX Gyre Heros Cn
++Helvetica Narrow        Nimbus Sans Narrow      TeX Gyre Heros Cn
+ Times                   Nimbus Roman            TeX Gyre Termes
+ Courier                 Nimbus Mono             TeX Gyre Cursor
+ ITC Avant Garde Gothic  URW Gothic              TeX Gyre Adventor
+@@ -73,14 +73,14 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	<alias binding="same">
+ 	  <family>Nimbus Sans Narrow</family>
+ 	  <default>
+-	  <family>Helvetica Condensed</family>
++	  <family>Helvetica Narrow</family>
+ 	  </default>
+ 	</alias>
+ 
+ 	<alias binding="same">
+ 	  <family>TeX Gyre Heros Cn</family>
+ 	  <default>
+-	  <family>Helvetica Condensed</family>
++	  <family>Helvetica Narrow</family>
+ 	  </default>
+ 	</alias>
+ 
+@@ -405,7 +405,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias>
+-	  <family>Helvetica Condensed</family>
++	  <family>Helvetica Narrow</family>
+ 	  <default>
+ 	  <family>Arial Narrow</family>
+ 	  </default>
+@@ -437,7 +437,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	<alias>
+ 	  <family>Arial Narrow</family>
+ 	  <default>
+-	  <family>Helvetica Condensed</family>
++	  <family>Helvetica Narrow</family>
+ 	  </default>
+ 	</alias>
+ 
+@@ -470,7 +470,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
+-	  <family>Helvetica Condensed</family>
++	  <family>Helvetica Narrow</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Heros Cn</family>
+ 	  <family>Nimbus Sans Narrow</family>
+-- 
+cgit v0.10.2
+

--- a/patches/fontconfig-2.12.1-urw-june-2016.patch
+++ b/patches/fontconfig-2.12.1-urw-june-2016.patch
@@ -1,0 +1,214 @@
+From 883b5cf48b0f699ed074b4d9b145b4bbc763b3b3 Mon Sep 17 00:00:00 2001
+From: Masamichi Hosoda <trueroad@trueroad.jp>
+Date: Wed, 24 Aug 2016 23:50:10 +0900
+Subject: Update aliases for URW June 2016
+
+http://git.ghostscript.com/?p=ghostpdl.git;a=commit;h=c8342b4a7b6cdcc4cb1261bf2b008f6df257b5c6
+http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=79bcdfb34fbce12b592cce389fa7a19da6b5b018
+
+diff --git a/conf.d/30-metric-aliases.conf b/conf.d/30-metric-aliases.conf
+index e72bf7a..1f0778d 100644
+--- a/conf.d/30-metric-aliases.conf
++++ b/conf.d/30-metric-aliases.conf
+@@ -6,17 +6,17 @@
+ 
+ Alias similar/metric-compatible families from various sources:
+ 
+-PostScript fonts:       URW fonts:              GUST fonts:        Windows fonts:
+-======================  ======================  =================  ==================
+-Helvetica               Nimbus Sans             TeX Gyre Heros
+-Helvetica Narrow        Nimbus Sans Narrow      TeX Gyre Heros Cn
+-Times                   Nimbus Roman            TeX Gyre Termes
+-Courier                 Nimbus Mono             TeX Gyre Cursor
+-ITC Avant Garde Gothic  URW Gothic              TeX Gyre Adventor
+-ITC Bookman             Bookman URW             TeX Gyre Bonum     Bookman Old Style
+-ITC Zapf Chancery       Chancery URW            TeX Gyre Chorus
+-Palatino                Palladio URW            TeX Gyre Pagella   Palatino Linotype
+-New Century Schoolbook  Century SchoolBook URW  TeX Gyre Schola    Century Schoolbook
++PostScript fonts:       URW fonts:           GUST fonts:        Windows fonts:
++======================  ==================  =================  ==================
++Helvetica               Nimbus Sans         TeX Gyre Heros
++Helvetica Narrow        Nimbus Sans Narrow  TeX Gyre Heros Cn
++Times                   Nimbus Roman        TeX Gyre Termes
++Courier                 Nimbus Mono PS      TeX Gyre Cursor
++ITC Avant Garde Gothic  URW Gothic          TeX Gyre Adventor
++ITC Bookman             URW Bookman         TeX Gyre Bonum     Bookman Old Style
++ITC Zapf Chancery       Z003                TeX Gyre Chorus
++Palatino                P052                TeX Gyre Pagella   Palatino Linotype
++New Century Schoolbook  C059                TeX Gyre Schola    Century Schoolbook
+ 
+ Microsoft fonts:  Liberation fonts:       Google CrOS core fonts:  StarOffice fonts:  AMT fonts:
+ ================  ======================  =======================  =================  ==============
+@@ -120,6 +120,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Nimbus Mono PS</family>
++	  <default>
++	  <family>Courier</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Cursor</family>
+ 	  <default>
+ 	  <family>Courier</family>
+@@ -176,6 +183,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>URW Bookman</family>
++	  <default>
++	  <family>ITC Bookman</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Bonum</family>
+ 	  <default>
+ 	  <family>ITC Bookman</family>
+@@ -211,6 +225,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>Z003</family>
++	  <default>
++	  <family>ITC Zapf Chancery</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Chorus</family>
+ 	  <default>
+ 	  <family>ITC Zapf Chancery</family>
+@@ -232,6 +253,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>P052</family>
++	  <default>
++	  <family>Palatino</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Pagella</family>
+ 	  <default>
+ 	  <family>Palatino</family>
+@@ -260,6 +288,13 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	</alias>
+ 
+ 	<alias binding="same">
++	  <family>C059</family>
++	  <default>
++	  <family>New Century Schoolbook</family>
++	  </default>
++	</alias>
++
++	<alias binding="same">
+ 	  <family>TeX Gyre Schola</family>
+ 	  <default>
+ 	  <family>New Century Schoolbook</family>
+@@ -490,6 +525,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>Courier</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Cursor</family>
++	  <family>Nimbus Mono PS</family>
+ 	  <family>Nimbus Mono</family>
+ 	  <family>Nimbus Mono L</family>
+ 	  </accept>
+@@ -509,6 +545,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Bookman Old Style</family>
+ 	  <family>TeX Gyre Bonum</family>
++	  <family>URW Bookman</family>
+ 	  <family>Bookman URW</family>
+ 	  <family>URW Bookman L</family>
+ 	  </accept>
+@@ -518,6 +555,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <family>ITC Zapf Chancery</family>
+ 	  <accept>
+ 	  <family>TeX Gyre Chorus</family>
++	  <family>Z003</family>
+ 	  <family>Chancery URW</family>
+ 	  <family>URW Chancery L</family>
+ 	  </accept>
+@@ -528,6 +566,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Palatino Linotype</family>
+ 	  <family>TeX Gyre Pagella</family>
++	  <family>P052</family>
+ 	  <family>Palladio URW</family>
+ 	  <family>URW Palladio L</family>
+ 	  </accept>
+@@ -538,6 +577,7 @@ but in an order preferring similar designs first.  We do this in three steps:
+ 	  <accept>
+ 	  <family>Century Schoolbook</family>
+ 	  <family>TeX Gyre Schola</family>
++	  <family>C059</family>
+ 	  <family>Century SchoolBook URW</family>
+ 	  <family>Century Schoolbook L</family>
+ 	  </accept>
+diff --git a/conf.d/30-urw-aliases.conf b/conf.d/30-urw-aliases.conf
+index e0d45da..cfde071 100644
+--- a/conf.d/30-urw-aliases.conf
++++ b/conf.d/30-urw-aliases.conf
+@@ -7,17 +7,26 @@
+   -->
+ 	<alias binding="same">
+ 	  <family>Zapf Dingbats</family>
+-	  <accept><family>Dingbats</family></accept>
++	  <accept>
++	    <family>D050000L</family>
++	    <family>Dingbats</family>
++	  </accept>
+ 	</alias>
+ 	<alias binding="same">
+ 	  <family>ITC Zapf Dingbats</family>
+-	  <accept><family>Dingbats</family></accept>
++	  <accept>
++	    <family>D050000L</family>
++	    <family>Dingbats</family>
++	  </accept>
+ 	</alias>
+ 	<match target="pattern">
+ 	  <test name="family" compare="eq" ignore-blanks="true">
+ 	    <string>Symbol</string>
+ 	  </test>
+ 	  <edit name="family" mode="append" binding="same">
++	    <string>Standard Symbols PS</string>
++	  </edit>
++	  <edit name="family" mode="append" binding="same">
+ 	    <string>Standard Symbols L</string>
+ 	  </edit>
+ 	</match>
+diff --git a/conf.d/45-latin.conf b/conf.d/45-latin.conf
+index 5228945..c6696f8 100644
+--- a/conf.d/45-latin.conf
++++ b/conf.d/45-latin.conf
+@@ -228,6 +228,10 @@
+ 		<default><family>monospace</family></default>
+ 	</alias>
+ 	<alias>
++		<family>Nimbus Mono PS</family>
++		<default><family>monospace</family></default>
++	</alias>
++	<alias>
+ 		<family>Terminal</family>
+ 		<default><family>monospace</family></default>
+ 	</alias>
+diff --git a/conf.d/60-latin.conf b/conf.d/60-latin.conf
+index 35600ea..23ee91b 100644
+--- a/conf.d/60-latin.conf
++++ b/conf.d/60-latin.conf
+@@ -43,6 +43,7 @@
+ 			<family>Luxi Mono</family>
+ 			<family>Nimbus Mono L</family>
+ 			<family>Nimbus Mono</family>
++			<family>Nimbus Mono PS</family>
+ 			<family>Courier</family>
+ 		</prefer>
+ 	</alias>
+-- 
+cgit v0.10.2
+

--- a/patches/ghostscript-9.20-cygwin.patch
+++ b/patches/ghostscript-9.20-cygwin.patch
@@ -1,0 +1,47 @@
+--- a/base/unix-gcc.mak	2016-09-26 19:41:28.000000000 +0900
++++ b/base/unix-gcc.mak	2016-10-22 21:17:21.112191200 +0900
+@@ -79,7 +79,7 @@
+ INSTALL_DATA = $(INSTALL) -m 644
+ INSTALL_SHARED = 
+ 
+-prefix = /usr/local
++prefix = /usr
+ exec_prefix = ${prefix}
+ bindir = ${exec_prefix}/bin
+ scriptdir = $(bindir)
+@@ -98,7 +98,7 @@
+ gssharedir = ${exec_prefix}/lib/ghostscript/$(GS_DOT_VERSION)
+ gsincludedir = ${prefix}/include/ghostscript/
+ 
+-docdir=$(gsdatadir)/doc
++docdir=$(gsdatadir)/doc/ghostscript-$(GS_DOT_VERSION)
+ exdir=$(gsdatadir)/examples
+ GS_DOCDIR=$(docdir)
+ 
+@@ -238,7 +238,7 @@
+ # You may need to change this if the libpng version changes.
+ # See png.mak for more information.
+ 
+-SHARE_LIBPNG=0
++SHARE_LIBPNG=1
+ PNGSRCDIR=./libpng
+ LIBPNG_NAME=png
+ 
+@@ -253,7 +253,7 @@
+ # Define the directory where the zlib sources are stored.
+ # See zlib.mak for more information.
+ 
+-SHARE_ZLIB=0
++SHARE_ZLIB=1
+ ZSRCDIR=./zlib
+ #ZLIB_NAME=gz
+ ZLIB_NAME=z
+@@ -377,7 +377,7 @@
+ CFLAGS_STANDARD= -O2
+ CFLAGS_DEBUG= -g -O0
+ CFLAGS_PROFILE=-pg  -O2
+-CFLAGS_SO=-fPIC
++#CFLAGS_SO=-fPIC
+ 
+ # Define the other compilation flags.  Add at most one of the following:
+ #	-DBSD4_2 for 4.2bsd systems.

--- a/patches/ghostscript-9.20-linux-useunix98.patch
+++ b/patches/ghostscript-9.20-linux-useunix98.patch
@@ -1,0 +1,10 @@
+--- a/base/unistd_.h	2016-10-23 02:21:58.750329900 +0900
++++ b/base/unistd_.h	2016-10-23 02:22:38.030553400 +0900
+@@ -55,6 +55,7 @@
+ #  define _XOPEN_SOURCE 500
+ #  define __USE_UNIX98
+ #  include <unistd.h>
++#  undef __USE_UNIX98
+ #endif
+ 
+ #endif   /* unistd__INCLUDED */

--- a/patches/ghostscript-9.20-make.patch
+++ b/patches/ghostscript-9.20-make.patch
@@ -1,5 +1,5 @@
 --- a/base/unix-dll.mak	2016-10-22 19:38:55.215410700 +0900
-+++ b/base/unix-dll.mak	2016-10-22 20:56:33.941391400 +0900
++++ b/base/unix-dll.mak	2016-10-23 11:08:32.498513200 +0900
 @@ -30,6 +30,11 @@
  SODIRPREFIX=so
  SODEBUGDIRPREFIX=sodebug
@@ -29,7 +29,7 @@
  #LDFLAGS_SO=-dynamiclib -flat_namespace
  #LDFLAGS_SO_MAC=-dynamiclib -install_name $(GS_SONAME_MAJOR_MINOR)
  #LDFLAGS_SO=-dynamiclib -install_name $(FRAMEWORK_NAME)
-+LDFLAGS_SO=-dynamiclib
++GS_LDFLAGS_SO=-dynamiclib
 +endif
 +
 +ifeq ($(TARGET),mingw)
@@ -39,7 +39,7 @@
 +GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
 +GS_SONAME_MAJOR=$(GS_SONAME_BASE)-$(GS_VERSION_MAJOR).$(GS_SOEXT)
 +GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE)-$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
-+LDFLAGS_SO=-shared -Wl,-soname=$(GS_SONAME_MAJOR_MINOR)
++GS_LDFLAGS_SO=-shared -Wl,-soname=$(GS_SONAME_MAJOR_MINOR)
 +endif
  
  GS_SO=$(BINDIR)/$(GS_SONAME)

--- a/patches/ghostscript-9.20-make.patch
+++ b/patches/ghostscript-9.20-make.patch
@@ -1,0 +1,112 @@
+--- a/base/unix-dll.mak	2016-10-22 19:38:55.215410700 +0900
++++ b/base/unix-dll.mak	2016-10-22 20:56:33.941391400 +0900
+@@ -30,6 +30,11 @@
+ SODIRPREFIX=so
+ SODEBUGDIRPREFIX=sodebug
+ 
++ifeq ($(TARGET),mingw)
++GS=gs
++XE=.exe
++endif
++
+ # ------------------- Ghostscript shared object --------------------------- #
+ 
+ # Shared object names
+@@ -90,14 +95,27 @@
+ # LDFLAGS_SO=-shared -Wl,$(LD_SET_DT_SONAME)$(LDFLAGS_SO_PREFIX)$(GS_SONAME_MAJOR)
+ 
+ 
++ifeq ($(TARGET),darwin)
+ # MacOS X
+-#GS_SOEXT=dylib
+-#GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
+-#GS_SONAME_MAJOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
+-#GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
++GS_SOEXT=dylib
++GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
++GS_SONAME_MAJOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_SOEXT)
++GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE).$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
+ #LDFLAGS_SO=-dynamiclib -flat_namespace
+ #LDFLAGS_SO_MAC=-dynamiclib -install_name $(GS_SONAME_MAJOR_MINOR)
+ #LDFLAGS_SO=-dynamiclib -install_name $(FRAMEWORK_NAME)
++LDFLAGS_SO=-dynamiclib
++endif
++
++ifeq ($(TARGET),mingw)
++# Mingw
++GS_SONAME_BASE=gs
++GS_SOEXT=dll
++GS_SONAME=$(GS_SONAME_BASE).$(GS_SOEXT)
++GS_SONAME_MAJOR=$(GS_SONAME_BASE)-$(GS_VERSION_MAJOR).$(GS_SOEXT)
++GS_SONAME_MAJOR_MINOR=$(GS_SONAME_BASE)-$(GS_VERSION_MAJOR).$(GS_VERSION_MINOR).$(GS_SOEXT)
++LDFLAGS_SO=-shared -Wl,-soname=$(GS_SONAME_MAJOR_MINOR)
++endif
+ 
+ GS_SO=$(BINDIR)/$(GS_SONAME)
+ GS_SO_MAJOR=$(BINDIR)/$(GS_SONAME_MAJOR)
+@@ -219,6 +237,8 @@
+ 
+ # ------------------------- Recursive make targets ------------------------- #
+ 
++# Help -rpath $ORIGIN survive the $(MAKE) command line expansion
++MAKE_LDFLAGS=$(subst $$,\$$$$,$(LDFLAGS))
+ SODEFS=\
+  GS_DOT_O= \
+  REALMAIN_OBJ= \
+@@ -278,13 +298,13 @@
+ 	$(MAKE) $(SUB_MAKE_OPTION) so-subtarget GENOPT='-DDEBUG' BUILDDIRPREFIX=$(SODEBUGDIRPREFIX)
+ 
+ so-only-subtarget:
+-	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' LDFLAGS='$(LDFLAGS)'\
++	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' LDFLAGS='$(MAKE_LDFLAGS)'\
+ 	 CFLAGS='$(CFLAGS_STANDARD) $(GCFLAGS) $(AC_CFLAGS) $(XCFLAGS)' prefix=$(prefix)\
+ 	 directories
+-	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' LDFLAGS='$(LDFLAGS)'\
++	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' LDFLAGS='$(MAKE_LDFLAGS)'\
+ 	 CFLAGS='$(CFLAGS_STANDARD) $(GCFLAGS) $(AC_CFLAGS) $(XCFLAGS)' prefix=$(prefix)\
+ 	 $(AUXDIR)/echogs$(XEAUX) $(AUXDIR)/genarch$(XEAUX)
+-	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' GS_LDFLAGS='$(LDFLAGS) $(GS_LDFLAGS_SO)'\
++	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) GENOPT='$(GENOPT)' GS_LDFLAGS='$(MAKE_LDFLAGS) $(GS_LDFLAGS_SO)'\
+          PCL_LDFLAGS='$(LDFLAGS) $(PCL_LDFLAGS_SO)' XPS_LDFLAGS='$(LDFLAGS) $(XPS_LDFLAGS_SO)' \
+ 	 CFLAGS='$(CFLAGS_STANDARD) $(CFLAGS_SO) $(GCFLAGS) $(AC_CFLAGS) $(XCFLAGS)'\
+ 	 prefix=$(prefix)
+@@ -293,7 +313,7 @@
+ 	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS) gs-so-strip $(PCL_TARGET)-so-strip $(XPS_TARGET)-so-strip $(GPDL_TARGET)-so-strip
+ 
+ so-subtarget: so-only-subtarget
+-	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS_FINAL) GENOPT='$(GENOPT)' LDFLAGS='$(LDFLAGS)'\
++	$(MAKE) $(SUB_MAKE_OPTION) $(SODEFS_FINAL) GENOPT='$(GENOPT)' LDFLAGS='$(MAKE_LDFLAGS)'\
+ 	 CFLAGS='$(CFLAGS_STANDARD) $(GCFLAGS) $(AC_CFLAGS) $(XCFLAGS)' prefix=$(prefix)\
+ 	 $(GSSOC_XE) $(GSSOX_XE) $(PCL_TARGET)-so-loader $(XPS_TARGET)-so-loader $(GPDL_TARGET)-so-loader
+ 
+--- a/base/unixlink.mak	2016-10-22 19:39:22.735691400 +0900
++++ b/base/unixlink.mak	2016-10-22 21:02:22.857540000 +0900
+@@ -57,6 +57,10 @@
+ 
+ GS_DOT_O=$(PSOBJ)gs.$(OBJ)
+ 
++# Help -rpath $ORIGIN survive the ECHOGS_XE sh command line expansion
++SHELL_LDFLAGS=$(subst $$,\$$,$(LDFLAGS))
++SHELL_GS_LDFLAGS=$(subst $$,\$$,$(GS_LDFLAGS))
++
+ # Here is the final link step.  The stuff with LD_RUN_PATH is for SVR4
+ # systems with dynamic library loading; I believe it's harmless elsewhere.
+ # The resetting of the environment variables to empty strings is for SCO Unix,
+@@ -65,7 +69,7 @@
+ 
+ $(GS_XE): $(ld_tr) $(gs_tr) $(ECHOGS_XE) $(XE_ALL) $(PSOBJ)gsromfs$(COMPILE_INITS).$(OBJ) \
+           $(UNIXLINK_MAK)
+-	$(ECHOGS_XE) -w $(ldt_tr) -n - $(CCLD) $(GS_LDFLAGS) -o $(GS_XE)
++	$(ECHOGS_XE) -w $(ldt_tr) -n - $(CCLD) $(SHELL_GS_LDFLAGS) -o $(GS_XE)
+ 	$(ECHOGS_XE) -a $(ldt_tr) -n -s $(PSOBJ)gsromfs$(COMPILE_INITS).$(OBJ) $(GS_DOT_O) -s
+ 	cat $(gsld_tr) >> $(ldt_tr)
+ 	$(ECHOGS_XE) -a $(ldt_tr) -s - $(EXTRALIBS) $(STDLIBS)
+@@ -158,7 +162,7 @@
+ 
+ $(APITEST_XE): $(ld_tr) $(ECHOGS_XE) $(XE_ALL) $(PSOBJ)gsromfs$(COMPILE_INITS).$(OBJ) $(PSOBJ)apitest.$(OBJ) \
+                $(UNIXLINK_MAK)
+-	$(ECHOGS_XE) -w $(ldt_tr) -n - $(CCLD) $(LDFLAGS) -o $(APITEST_XE)
++	$(ECHOGS_XE) -w $(ldt_tr) -n - $(CCLD) $(SHELL_LDFLAGS) -o $(APITEST_XE)
+ 	$(ECHOGS_XE) -a $(ldt_tr) -n -s $(PSOBJ)gsromfs$(COMPILE_INITS).$(OBJ) $(PSOBJ)apitest.$(OBJ) -s
+ 	cat $(ld_tr) >>$(ldt_tr)
+ 	$(ECHOGS_XE) -a $(ldt_tr) -s - $(EXTRALIBS) $(STDLIBS)

--- a/patches/ghostscript-9.20-mingw-struct-stat.patch
+++ b/patches/ghostscript-9.20-mingw-struct-stat.patch
@@ -1,0 +1,22 @@
+--- a/base/stat_.h	2016-09-26 19:41:28.000000000 +0900
++++ b/base/stat_.h	2016-10-23 16:55:54.643168000 +0900
+@@ -53,7 +53,7 @@
+ /* Find permissions for file */
+ /* Ideally this would defined in gp.h, but the macroisms mean it has to be
+  * defined here. */
+-extern int gp_stat(const char *path, struct stat *buf);
++extern int gp_stat(const char *path, struct_stat *buf);
+ 
+ /*
+  * Some (System V?) systems test for directories in a slightly different way.
+--- a/base/gp_mswin.c	2016-10-22 21:22:49.843896700 +0900
++++ b/base/gp_mswin.c	2016-10-23 16:57:11.748323800 +0900
+@@ -788,7 +788,7 @@
+ #endif
+ }
+ 
+-int gp_stat(const char *path, struct _stat *buf)
++int gp_stat(const char *path, struct_stat *buf)
+ {
+ #ifdef GS_NO_UTF8
+     return stat(path, buf);

--- a/patches/ghostscript-9.20-mingw-unix-aux.patch
+++ b/patches/ghostscript-9.20-mingw-unix-aux.patch
@@ -1,0 +1,13 @@
+--- a/base/unix-aux.mak	2016-09-26 19:41:28.000000000 +0900
++++ b/base/unix-aux.mak	2016-10-23 12:11:54.535614400 +0900
+@@ -28,9 +28,7 @@
+ 
+ # Unix platforms other than System V, and also System V Release 4
+ # (SVR4) platforms.
+-unix__=$(GLOBJ)gp_getnv.$(OBJ) $(GLOBJ)gp_upapr.$(OBJ) $(GLOBJ)gp_unix.$(OBJ)\
+-       $(GLOBJ)gp_unifs.$(OBJ) $(GLOBJ)gp_unifn.$(OBJ) $(GLOBJ)gp_stdia.$(OBJ)\
+-       $(GLOBJ)gp_nxpsprn.$(OBJ)
++unix__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_stdia.$(OBJ) $(GLOBJ)gp_ntfs.$(OBJ) $(GLOBJ)gp_win32.$(OBJ) $(GLOBJ)gp_upapr.$(OBJ)  $(GLOBJ)gp_wutf8.$(OBJ)
+ 
+ $(GLGEN)unix_.dev: $(unix__) $(GLD)nosync.dev $(GLD)smd5.dev $(UNIX_AUX_MAK) $(MAKEDIRS)
+ 	$(SETMOD) $(GLGEN)unix_ $(unix__) -include $(GLD)nosync

--- a/patches/ghostscript-9.20-mingw-unix-aux.patch
+++ b/patches/ghostscript-9.20-mingw-unix-aux.patch
@@ -7,7 +7,7 @@
 -unix__=$(GLOBJ)gp_getnv.$(OBJ) $(GLOBJ)gp_upapr.$(OBJ) $(GLOBJ)gp_unix.$(OBJ)\
 -       $(GLOBJ)gp_unifs.$(OBJ) $(GLOBJ)gp_unifn.$(OBJ) $(GLOBJ)gp_stdia.$(OBJ)\
 -       $(GLOBJ)gp_nxpsprn.$(OBJ)
-+unix__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_stdia.$(OBJ) $(GLOBJ)gp_ntfs.$(OBJ) $(GLOBJ)gp_win32.$(OBJ) $(GLOBJ)gp_upapr.$(OBJ)  $(GLOBJ)gp_wutf8.$(OBJ)
++unix__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_stdia.$(OBJ) $(GLOBJ)gp_ntfs.$(OBJ) $(GLOBJ)gp_win32.$(OBJ) $(GLOBJ)gp_upapr.$(OBJ)  $(GLOBJ)gp_wutf8.$(OBJ) $(GLOBJ)gp_nxpsprn.$(OBJ)
  
  $(GLGEN)unix_.dev: $(unix__) $(GLD)nosync.dev $(GLD)smd5.dev $(UNIX_AUX_MAK) $(MAKEDIRS)
  	$(SETMOD) $(GLGEN)unix_ $(unix__) -include $(GLD)nosync

--- a/patches/ghostscript-9.20-windows-make.patch
+++ b/patches/ghostscript-9.20-windows-make.patch
@@ -1,0 +1,264 @@
+--- /dev/null	2016-10-23 12:27:12.964921700 +0900
++++ b/base/gsdll.mak	2016-10-23 12:29:17.112570200 +0900
+@@ -0,0 +1,30 @@
++# Copyright (C) 2001-2016 Artifex Software, Inc.
++# All Rights Reserved.
++#
++# This software is provided AS-IS with no warranty, either express or
++# implied.
++#
++# This software is distributed under license and may not be copied,
++# modified or distributed except as expressly authorized under the terms
++# of the license contained in the file LICENSE in this distribution.
++#
++# Refer to licensing information at http://www.artifex.com or contact
++# Artifex Software, Inc.,  7 Mt. Lassen Drive - Suite A-134, San Rafael,
++# CA  94903, U.S.A., +1(415)492-9861, for further information.
++#
++#
++# Common interpreter makefile section for 32-bit MS Windows.
++
++# This makefile must be acceptable to Microsoft Visual C++, Watcom C++,
++# and Borland C++.  For this reason, the only conditional directives
++# allowed are !if[n]def, !else, and !endif.
++
++# Compile gsdll.c, the main program of the DLL.
++
++$(PSOBJ)gsdll.obj: $(PSSRC)gsdll.c $(AK) $(iapi_h) $(ghost_h) $(WININT_MAK)
++	$(PSCCWIN) $(COMPILE_FOR_DLL) $(PSO_)gsdll.$(OBJ) $(C_) $(PSSRC)gsdll.c
++
++$(GLOBJ)gp_msdll.obj: $(GLSRC)gp_msdll.c $(AK) $(iapi_h) $(WININT_MAK)
++	$(PSCCWIN) $(COMPILE_FOR_DLL) $(GLO_)gp_msdll.$(OBJ) $(C_) $(GLSRC)gp_msdll.c
++
++# end of gsdll.mak
+--- a/psi/winint.mak	2016-09-26 19:41:29.000000000 +0900
++++ b/psi/winint.mak	2016-10-23 12:31:21.162847300 +0900
+@@ -111,13 +111,7 @@
+  $(dwdll_h) $(iapi_h) $(WININT_MAK)
+ 	$(PSCCWIN) $(COMPILE_FOR_EXE) $(PSO_)dwnodll.obj $(C_) $(PSSRC)dwnodll.c
+ 
+-# Compile gsdll.c, the main program of the DLL.
+-
+-$(PSOBJ)gsdll.obj: $(PSSRC)gsdll.c $(AK) $(iapi_h) $(ghost_h) $(WININT_MAK)
+-	$(PSCCWIN) $(COMPILE_FOR_DLL) $(PSO_)gsdll.$(OBJ) $(C_) $(PSSRC)gsdll.c
+-
+-$(GLOBJ)gp_msdll.obj: $(GLSRC)gp_msdll.c $(AK) $(iapi_h) $(WININT_MAK)
+-	$(PSCCWIN) $(COMPILE_FOR_DLL) $(GLO_)gp_msdll.$(OBJ) $(C_) $(GLSRC)gp_msdll.c
++!include $(GLSRCDIR)\gsdll.mak
+ 
+ # Modules for console mode EXEs
+ 
+--- a/base/winlib.mak	2016-09-26 19:41:28.000000000 +0900
++++ b/base/winlib.mak	2016-10-23 12:33:46.120449400 +0900
+@@ -179,95 +179,6 @@
+ $(gconfig__h): $(TOP_MAKEFILES)
+ 	$(ECHOGS_XE) -w $(gconfig__h) -x 2f2a20 This file deliberately left blank. -x 2a2f
+ 
+-# -------------------------------- Library -------------------------------- #
+-
+-# The Windows Win32 platform
+-
+-mswin32__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_wpapr.$(OBJ) \
+- $(GLOBJ)gp_stdia.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
+-mswin32_inc=$(GLD)nosync.dev $(GLD)winplat.dev
+-
+-$(GLGEN)mswin32_.dev:  $(mswin32__) $(ECHOGS_XE) $(mswin32_inc) $(WINLIB_MAK)
+-	$(SETMOD) $(GLGEN)mswin32_ $(mswin32__)
+-	$(ADDMOD) $(GLGEN)mswin32_ -include $(mswin32_inc)
+-
+-$(GLOBJ)gp_mswin.$(OBJ): $(GLSRC)gp_mswin.c $(AK) $(gp_mswin_h) \
+- $(ctype__h) $(dos__h) $(malloc__h) $(memory__h) $(pipe__h) \
+- $(stdio__h) $(string__h) $(windows__h) \
+- $(gx_h) $(gp_h) $(gpcheck_h) $(gpmisc_h) $(gserrors_h) $(gsexit_h) \
+- $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_mswin.$(OBJ) $(C_) $(GLSRC)gp_mswin.c
+-
+-$(GLOBJ)gp_wutf8.$(OBJ): $(GLSRC)gp_wutf8.c $(windows__h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_wutf8.$(OBJ) $(C_) $(GLSRC)gp_wutf8.c
+-
+-$(AUX)gp_wutf8.$(OBJ): $(GLSRC)gp_wutf8.c $(windows__h) $(WINLIB_MAK)
+-	$(GLCCAUX) $(AUXO_)gp_wutf8.$(OBJ) $(C_) $(GLSRC)gp_wutf8.c
+-
+-$(GLOBJ)gp_wgetv.$(OBJ): $(GLSRC)gp_wgetv.c $(AK) $(gscdefs_h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_wgetv.$(OBJ) $(C_) $(GLSRC)gp_wgetv.c
+-
+-$(GLOBJ)gp_wpapr.$(OBJ): $(GLSRC)gp_wpapr.c $(AK) $(gp_h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_wpapr.$(OBJ) $(C_) $(GLSRC)gp_wpapr.c
+-
+-$(GLOBJ)gp_stdia.$(OBJ): $(GLSRC)gp_stdia.c $(AK)\
+-  $(stdio__h) $(time__h) $(unistd__h) $(gx_h) $(gp_h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_stdia.$(OBJ) $(C_) $(GLSRC)gp_stdia.c
+-
+-# The Metro platform
+-!ifdef METRO
+-METRO_OBJS=$(GLOBJ)winrtsup.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
+-
+-$(GLOBJ)winrtsup.$(OBJ): $(GLSRCDIR)/winrtsup.cpp $(WINLIB_MAK)
+-	$(GLCCWIN) /EHsc $(GLO_)winrtsup.$(OBJ) $(C_) $(GLSRCDIR)/winrtsup.cpp
+-!else
+-METRO_OBJS=
+-!endif
+-
+-
+-metro__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_wpapr.$(OBJ)\
+-  $(GLOBJ)gp_stdia.$(OBJ) $(METRO_OBJS)
+-#$(GLOBJ)gp_wutf8.$(OBJ)
+-metro_inc=$(GLD)nosync.dev $(GLD)winplat.dev
+-
+-$(GLGEN)metro_.dev:  $(metro__) $(ECHOGS_XE) $(metro_inc) $(WINLIB_MAK)
+-	$(SETMOD) $(GLGEN)metro_ $(metro__)
+-	$(ADDMOD) $(GLGEN)metro_ -include $(metro_inc)
+-
+-
+-# Define MS-Windows handles (file system) as a separable feature.
+-
+-mshandle_=$(GLOBJ)gp_mshdl.$(OBJ)
+-$(GLD)mshandle.dev: $(ECHOGS_XE) $(mshandle_) $(WINLIB_MAK)
+-	$(SETMOD) $(GLD)mshandle $(mshandle_)
+-	$(ADDMOD) $(GLD)mshandle -iodev handle
+-
+-$(GLOBJ)gp_mshdl.$(OBJ): $(GLSRC)gp_mshdl.c $(AK)\
+- $(ctype__h) $(errno__h) $(stdio__h) $(string__h)\
+- $(gsmemory_h) $(gstypes_h) $(gxiodev_h) $(gserrors_h) $(WINLIB_MAK)
+-	$(GLCC) $(GLO_)gp_mshdl.$(OBJ) $(C_) $(GLSRC)gp_mshdl.c
+-
+-# Define MS-Windows printer (file system) as a separable feature.
+-
+-msprinter_=$(GLOBJ)gp_msprn.$(OBJ)
+-
+-$(GLD)msprinter.dev: $(msprinter_) $(WINLIB_MAK)
+-	$(SETMOD) $(GLD)msprinter $(msprinter_)
+-	$(ADDMOD) $(GLD)msprinter -iodev printer
+-
+-$(GLOBJ)gp_msprn.$(OBJ): $(GLSRC)gp_msprn.c $(AK)\
+- $(ctype__h) $(errno__h) $(stdio__h) $(string__h)\
+- $(gsmemory_h) $(gstypes_h) $(gxiodev_h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_msprn.$(OBJ) $(C_) $(GLSRC)gp_msprn.c
+-
+-# Define MS-Windows polling as a separable feature
+-# because it is not needed by the gslib.
+-mspoll_=$(GLOBJ)gp_mspol.$(OBJ)
+-$(GLD)mspoll.dev: $(ECHOGS_XE) $(mspoll_) $(WINLIB_MAK)
+-	$(SETMOD) $(GLD)mspoll $(mspoll_)
+-
+-$(GLOBJ)gp_mspol.$(OBJ): $(GLSRC)gp_mspol.c $(AK)\
+- $(gx_h) $(gp_h) $(gpcheck_h) $(WINLIB_MAK)
+-	$(GLCCWIN) $(GLO_)gp_mspol.$(OBJ) $(C_) $(GLSRC)gp_mspol.c
++!include $(GLSRCDIR)\w32.mak
+ 
+ # end of winlib.mak
+--- /dev/null	2016-10-23 12:32:37.002198500 +0900
++++ b/base/w32.mak	2016-10-23 12:34:57.160713400 +0900
+@@ -0,0 +1,112 @@
++# Copyright (C) 2001-2012 Artifex Software, Inc.
++# All Rights Reserved.
++#
++# This software is provided AS-IS with no warranty, either express or
++# implied.
++#
++# This software is distributed under license and may not be copied,
++# modified or distributed except as expressly authorized under the terms
++# of the license contained in the file LICENSE in this distribution.
++#
++# Refer to licensing information at http://www.artifex.com or contact
++# Artifex Software, Inc.,  7 Mt. Lassen Drive - Suite A-134, San Rafael,
++# CA  94903, U.S.A., +1(415)492-9861, for further information.
++#
++# Common makefile section for 32-bit MS Windows.
++
++# This makefile must be acceptable to Microsoft Visual C++, Watcom C++,
++# and Borland C++.  For this reason, the only conditional directives
++# allowed are !if[n]def, !else, and !endif.
++
++# -------------------------------- Library -------------------------------- #
++
++# The Windows Win32 platform
++
++mswin32__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_wpapr.$(OBJ) \
++ $(GLOBJ)gp_stdia.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
++mswin32_inc=$(GLD)nosync.dev $(GLD)winplat.dev
++
++$(GLGEN)mswin32_.dev:  $(mswin32__) $(ECHOGS_XE) $(mswin32_inc) $(WINLIB_MAK)
++	$(SETMOD) $(GLGEN)mswin32_ $(mswin32__)
++	$(ADDMOD) $(GLGEN)mswin32_ -include $(mswin32_inc)
++
++$(GLOBJ)gp_mswin.$(OBJ): $(GLSRC)gp_mswin.c $(AK) $(gp_mswin_h) \
++ $(ctype__h) $(dos__h) $(malloc__h) $(memory__h) $(pipe__h) \
++ $(stdio__h) $(string__h) $(windows__h) \
++ $(gx_h) $(gp_h) $(gpcheck_h) $(gpmisc_h) $(gserrors_h) $(gsexit_h) \
++ $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_mswin.$(OBJ) $(C_) $(GLSRC)gp_mswin.c
++
++$(GLOBJ)gp_wutf8.$(OBJ): $(GLSRC)gp_wutf8.c $(windows__h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_wutf8.$(OBJ) $(C_) $(GLSRC)gp_wutf8.c
++
++$(AUX)gp_wutf8.$(OBJ): $(GLSRC)gp_wutf8.c $(windows__h) $(WINLIB_MAK)
++	$(GLCCAUX) $(AUXO_)gp_wutf8.$(OBJ) $(C_) $(GLSRC)gp_wutf8.c
++
++$(GLOBJ)gp_wgetv.$(OBJ): $(GLSRC)gp_wgetv.c $(AK) $(gscdefs_h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_wgetv.$(OBJ) $(C_) $(GLSRC)gp_wgetv.c
++
++$(GLOBJ)gp_wpapr.$(OBJ): $(GLSRC)gp_wpapr.c $(AK) $(gp_h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_wpapr.$(OBJ) $(C_) $(GLSRC)gp_wpapr.c
++
++$(GLOBJ)gp_stdia.$(OBJ): $(GLSRC)gp_stdia.c $(AK)\
++  $(stdio__h) $(time__h) $(unistd__h) $(gx_h) $(gp_h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_stdia.$(OBJ) $(C_) $(GLSRC)gp_stdia.c
++
++# The Metro platform
++!ifdef METRO
++METRO_OBJS=$(GLOBJ)winrtsup.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
++
++$(GLOBJ)winrtsup.$(OBJ): $(GLSRCDIR)/winrtsup.cpp $(WINLIB_MAK)
++	$(GLCCWIN) /EHsc $(GLO_)winrtsup.$(OBJ) $(C_) $(GLSRCDIR)/winrtsup.cpp
++!else
++METRO_OBJS=
++!endif
++
++
++metro__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_wpapr.$(OBJ)\
++  $(GLOBJ)gp_stdia.$(OBJ) $(METRO_OBJS)
++#$(GLOBJ)gp_wutf8.$(OBJ)
++metro_inc=$(GLD)nosync.dev $(GLD)winplat.dev
++
++$(GLGEN)metro_.dev:  $(metro__) $(ECHOGS_XE) $(metro_inc) $(WINLIB_MAK)
++	$(SETMOD) $(GLGEN)metro_ $(metro__)
++	$(ADDMOD) $(GLGEN)metro_ -include $(metro_inc)
++
++
++# Define MS-Windows handles (file system) as a separable feature.
++
++mshandle_=$(GLOBJ)gp_mshdl.$(OBJ)
++$(GLD)mshandle.dev: $(ECHOGS_XE) $(mshandle_) $(WINLIB_MAK)
++	$(SETMOD) $(GLD)mshandle $(mshandle_)
++	$(ADDMOD) $(GLD)mshandle -iodev handle
++
++$(GLOBJ)gp_mshdl.$(OBJ): $(GLSRC)gp_mshdl.c $(AK)\
++ $(ctype__h) $(errno__h) $(stdio__h) $(string__h)\
++ $(gsmemory_h) $(gstypes_h) $(gxiodev_h) $(gserrors_h) $(WINLIB_MAK)
++	$(GLCC) $(GLO_)gp_mshdl.$(OBJ) $(C_) $(GLSRC)gp_mshdl.c
++
++# Define MS-Windows printer (file system) as a separable feature.
++
++msprinter_=$(GLOBJ)gp_msprn.$(OBJ)
++
++$(GLD)msprinter.dev: $(msprinter_) $(WINLIB_MAK)
++	$(SETMOD) $(GLD)msprinter $(msprinter_)
++	$(ADDMOD) $(GLD)msprinter -iodev printer
++
++$(GLOBJ)gp_msprn.$(OBJ): $(GLSRC)gp_msprn.c $(AK)\
++ $(ctype__h) $(errno__h) $(stdio__h) $(string__h)\
++ $(gsmemory_h) $(gstypes_h) $(gxiodev_h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_msprn.$(OBJ) $(C_) $(GLSRC)gp_msprn.c
++
++# Define MS-Windows polling as a separable feature
++# because it is not needed by the gslib.
++mspoll_=$(GLOBJ)gp_mspol.$(OBJ)
++$(GLD)mspoll.dev: $(ECHOGS_XE) $(mspoll_) $(WINLIB_MAK)
++	$(SETMOD) $(GLD)mspoll $(mspoll_)
++
++$(GLOBJ)gp_mspol.$(OBJ): $(GLSRC)gp_mspol.c $(AK)\
++ $(gx_h) $(gp_h) $(gpcheck_h) $(WINLIB_MAK)
++	$(GLCCWIN) $(GLO_)gp_mspol.$(OBJ) $(C_) $(GLSRC)gp_mspol.c
++
++# end of w32.mak

--- a/patches/ghostscript-9.20-windows-make.patch
+++ b/patches/ghostscript-9.20-windows-make.patch
@@ -206,14 +206,14 @@
 +	$(GLCCWIN) $(GLO_)gp_stdia.$(OBJ) $(C_) $(GLSRC)gp_stdia.c
 +
 +# The Metro platform
-+!ifdef METRO
-+METRO_OBJS=$(GLOBJ)winrtsup.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
-+
-+$(GLOBJ)winrtsup.$(OBJ): $(GLSRCDIR)/winrtsup.cpp $(WINLIB_MAK)
-+	$(GLCCWIN) /EHsc $(GLO_)winrtsup.$(OBJ) $(C_) $(GLSRCDIR)/winrtsup.cpp
-+!else
++#!ifdef METRO
++#METRO_OBJS=$(GLOBJ)winrtsup.$(OBJ) $(GLOBJ)gp_wutf8.$(OBJ)
++#
++#$(GLOBJ)winrtsup.$(OBJ): $(GLSRCDIR)/winrtsup.cpp $(WINLIB_MAK)
++#	$(GLCCWIN) /EHsc $(GLO_)winrtsup.$(OBJ) $(C_) $(GLSRCDIR)/winrtsup.cpp
++#!else
 +METRO_OBJS=
-+!endif
++#!endif
 +
 +
 +metro__=$(GLOBJ)gp_mswin.$(OBJ) $(GLOBJ)gp_wgetv.$(OBJ) $(GLOBJ)gp_wpapr.$(OBJ)\

--- a/patches/ghostscript-9.20-windows-snprintf.patch
+++ b/patches/ghostscript-9.20-windows-snprintf.patch
@@ -1,0 +1,15 @@
+--- a/base/gp_mswin.c	2016-10-22 21:19:28.962063600 +0900
++++ b/base/gp_mswin.c	2016-10-22 21:22:49.843896700 +0900
+@@ -978,6 +978,7 @@
+ /* Microsoft Visual C++ 2005  doesn't properly define snprintf,
+    which is defined in the C standard ISO/IEC 9899:1999 (E) */
+ 
++#if !defined(__CYGWIN__) && !defined(__MINGW32__)
+ int snprintf(char *buffer, size_t count, const char *format, ...)
+ {
+     if (count > 0) {
+@@ -993,3 +994,4 @@
+         return 0;
+ }
+ #endif
++#endif


### PR DESCRIPTION
This updates GUB's Ghostscript from 9.15 to 9.20.
gs-9.20 are fixed several font handling bugs and PDF destination name bug etc.

It also includes GCC updates from 4.9.2 to 4.9.4
because GCC 4.9.2 cannot compile some packages in my environment.

Unfortunately, Ghostscript 9.20 for freebsd-x86 raises seg fault.
So for freebsd-x86, Ghostscript 9.15 is used.
