### PR TITLE
Use Extract PDFmark

### DIFF
--- a/gub/specs/extractpdfmark.py
+++ b/gub/specs/extractpdfmark.py
@@ -1,0 +1,6 @@
+#
+from gub import tools
+
+class Extractpdfmark__tools (tools.AutoBuild):
+    source = 'https://github.com/trueroad/extractpdfmark/releases/download/v1.0.1/extractpdfmark-1.0.1.tar.gz'
+    dependencies = ['tools::poppler']

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -376,6 +376,15 @@ cd %(builddir)s && sort -u gconfig_-native.h gconfig_-tools.h | grep "^#define" 
                 )
     def packaging_suffix_dir (self):
         return ''
+    def install (self):
+        tools.AutoBuild.install (self)
+        self.system ('mkdir -p %(install_root)s/usr/etc/relocate')
+        self.dump ('''
+prependdir GS_FONTPATH=$INSTALLER_PREFIX/share/ghostscript/%(version)s/fonts
+prependdir GS_FONTPATH=$INSTALLER_PREFIX/share/gs/fonts
+prependdir GS_LIB=$INSTALLER_PREFIX/share/ghostscript/%(version)s/Resource
+prependdir GS_LIB=$INSTALLER_PREFIX/share/ghostscript/%(version)s/Resource/Init
+''', '%(install_root)s/usr/etc/relocate/gs.reloc')
 
 def test ():
     printf ('Ghostscript.static_version:', Ghostscript.static_version ())

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -374,6 +374,8 @@ cd %(builddir)s && sort -u gconfig_-native.h gconfig_-tools.h | grep "^#define" 
                 + ' docdir=%(prefix_dir)s/share/doc/ghostscript/doc '
                 + ' exdir=%(prefix_dir)s/share/doc/ghostscript/examples '
                 )
+    def packaging_suffix_dir (self):
+        return ''
 
 def test ():
     printf ('Ghostscript.static_version:', Ghostscript.static_version ())

--- a/gub/specs/icoutils.py
+++ b/gub/specs/icoutils.py
@@ -1,7 +1,8 @@
 from gub import tools
 
 class Icoutils__tools (tools.AutoBuild):
-    dependencies = ['libpng-devel']
+    source = 'http://download.savannah.gnu.org/releases/icoutils/icoutils-0.31.0.tar.bz2'
+    dependencies = ['libpng-devel', 'tools::bzip2']
     configure_flags = (tools.AutoBuild.configure_flags
                        + ' --with-libintl-prefix=%(system_prefix)s'
                        + ' --disable-nls')

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -31,12 +31,12 @@ class LilyPond_doc (lilypond.LilyPond_base):
         # system::xetex uses system's shared libraries instead of GUB's ones.
         if 'system::xetex' in self.dependencies:
             self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
-                           '%(srcdir)s/scripts/build/xetex-with-options.sh')
+                           '%(builddir)s/scripts/build/out/xetex-with-options')
         # system::xelatex uses system's shared libraries instead of GUB's ones.
         if 'system::xelatex' in self.dependencies:
             self.file_sub ([('^exec xelatex ',
                              'LD_LIBRARY_PATH= exec xelatex ')],
-                           '%(srcdir)s/scripts/build/xelatex-with-options.sh')
+                           '%(builddir)s/scripts/build/out/xelatex-with-options')
     make_flags = misc.join_lines ('''
 CROSS=no
 DOCUMENTATION=yes

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -25,9 +25,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::texinfo',
                 'system::zip',
                 ])
-    def stages (self):
-        return ['patch'] + lilypond.LilyPond_base.stages (self)
-    def patch (self):
+    def compile (self):
         # system::xetex uses system's shared libraries instead of GUB's ones.
         self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
                        '%(builddir)s/scripts/build/out/xetex-with-options')
@@ -39,6 +37,7 @@ class LilyPond_doc (lilypond.LilyPond_base):
         self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
                          'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
                        '%(builddir)s/config.make')
+        lilypond.LilyPond_base.compile (self)
     make_flags = misc.join_lines ('''
 CROSS=no
 DOCUMENTATION=yes

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -23,8 +23,6 @@ class LilyPond_doc (lilypond.LilyPond_base):
                 'tools::fonts-ipafont',
                 'tools::fonts-gnufreefont',
                 'tools::texinfo',
-                'system::xetex',
-                'system::xelatex',
                 'system::zip',
                 ])
     def stages (self):

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -37,6 +37,11 @@ class LilyPond_doc (lilypond.LilyPond_base):
         self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
                          'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
                        '%(builddir)s/config.make')
+        # The timestamp of these scripts should not be older than config.make.
+        # Otherwise, they will be regenerated from the source directory
+        # and the above substitutes will be lost.
+        self.system ('touch %(builddir)s/scripts/build/out/xetex-with-options')
+        self.system ('touch %(builddir)s/scripts/build/out/xelatex-with-options')
         lilypond.LilyPond_base.compile (self)
     make_flags = misc.join_lines ('''
 CROSS=no

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -29,14 +29,12 @@ class LilyPond_doc (lilypond.LilyPond_base):
         return ['patch'] + lilypond.LilyPond_base.stages (self)
     def patch (self):
         # system::xetex uses system's shared libraries instead of GUB's ones.
-        if 'system::xetex' in self.dependencies:
-            self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
-                           '%(builddir)s/scripts/build/out/xetex-with-options')
+        self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
+                       '%(builddir)s/scripts/build/out/xetex-with-options')
         # system::xelatex uses system's shared libraries instead of GUB's ones.
-        if 'system::xelatex' in self.dependencies:
-            self.file_sub ([('^exec xelatex ',
-                             'LD_LIBRARY_PATH= exec xelatex ')],
-                           '%(builddir)s/scripts/build/out/xelatex-with-options')
+        self.file_sub ([('^exec xelatex ',
+                         'LD_LIBRARY_PATH= exec xelatex ')],
+                       '%(builddir)s/scripts/build/out/xelatex-with-options')
     make_flags = misc.join_lines ('''
 CROSS=no
 DOCUMENTATION=yes

--- a/gub/specs/lilypond-doc.py
+++ b/gub/specs/lilypond-doc.py
@@ -35,6 +35,10 @@ class LilyPond_doc (lilypond.LilyPond_base):
         self.file_sub ([('^exec xelatex ',
                          'LD_LIBRARY_PATH= exec xelatex ')],
                        '%(builddir)s/scripts/build/out/xelatex-with-options')
+        # tools::extractpdfmark uses system's libstdc++ instead of GUB's one.
+        self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
+                         'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
+                       '%(builddir)s/config.make')
     make_flags = misc.join_lines ('''
 CROSS=no
 DOCUMENTATION=yes

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -44,6 +44,11 @@ LD_PRELOAD= tar -C %(builddir)s -cjf %(test_ball)s input/regression/out-test
         self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
                          'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
                        '%(builddir)s/config.make')
+        # The timestamp of these scripts should not be older than config.make.
+        # Otherwise, they will be regenerated from the source directory
+        # and the above substitutes will be lost.
+        self.system ('touch %(builddir)s/scripts/build/out/xetex-with-options')
+        self.system ('touch %(builddir)s/scripts/build/out/xelatex-with-options')
         lilypond.LilyPond_base.compile (self)
 
 Lilypond_test = LilyPond_test

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -32,5 +32,19 @@ CPU_COUNT=%(cpu_count)s
         self.system ('''
 LD_PRELOAD= tar -C %(builddir)s -cjf %(test_ball)s input/regression/out-test
 ''')
+    def stages (self):
+        return ['patch'] + lilypond.LilyPond_base.stages (self)
+    def patch (self):
+        # system::xetex uses system's shared libraries instead of GUB's ones.
+        self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
+                       '%(builddir)s/scripts/build/out/xetex-with-options')
+        # system::xelatex uses system's shared libraries instead of GUB's ones.
+        self.file_sub ([('^exec xelatex ',
+                         'LD_LIBRARY_PATH= exec xelatex ')],
+                       '%(builddir)s/scripts/build/out/xelatex-with-options')
+        # tools::extractpdfmark uses system's libstdc++ instead of GUB's one.
+        self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
+                         'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
+                       '%(builddir)s/config.make')
 
 Lilypond_test = LilyPond_test

--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -32,9 +32,7 @@ CPU_COUNT=%(cpu_count)s
         self.system ('''
 LD_PRELOAD= tar -C %(builddir)s -cjf %(test_ball)s input/regression/out-test
 ''')
-    def stages (self):
-        return ['patch'] + lilypond.LilyPond_base.stages (self)
-    def patch (self):
+    def compile (self):
         # system::xetex uses system's shared libraries instead of GUB's ones.
         self.file_sub ([('^exec xetex ', 'LD_LIBRARY_PATH= exec xetex ')],
                        '%(builddir)s/scripts/build/out/xetex-with-options')
@@ -46,5 +44,6 @@ LD_PRELOAD= tar -C %(builddir)s -cjf %(test_ball)s input/regression/out-test
         self.file_sub ([('^EXTRACTPDFMARK = ([^L].*)$',
                          'EXTRACTPDFMARK = LD_LIBRARY_PATH=%(tools_prefix)s/lib \\1')],
                        '%(builddir)s/config.make')
+        lilypond.LilyPond_base.compile (self)
 
 Lilypond_test = LilyPond_test

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -53,6 +53,8 @@ sheet music from a high-level description file.'''
 
         'system::mf', 
         'system::mpost', 
+        'system::xetex',
+        'system::xelatex',
         ]
     if 'stat' in misc.librestrict ():
         dependencies = [x for x in dependencies

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -47,6 +47,8 @@ sheet music from a high-level description file.'''
         'tools::t1utils',
         'tools::texi2html',
         'tools::texinfo',
+        'tools::ghostscript',
+        'tools::extractpdfmark',
         #'tools::texlive',
 
         'system::mf', 

--- a/gub/specs/poppler.py
+++ b/gub/specs/poppler.py
@@ -1,8 +1,9 @@
 from gub import target
+from gub import tools
 
 class Poppler (target.AutoBuild):
-    source = 'http://poppler.freedesktop.org/poppler-0.11.2.tar.gz'
-    dependencies = ['tools::libtool', 'tools::glib',
+    source = 'https://poppler.freedesktop.org/poppler-0.49.0.tar.xz'
+    dependencies = ['tools::libtool', 'tools::glib', 'tools::xzutils',
                 'zlib-devel',
                 'fontconfig-devel',
                 'gtk+-devel',
@@ -30,3 +31,19 @@ class Poppler__darwin (Poppler):
                 if x.replace ('-devel', '') not in [
                 'libxml2', # Included in darwin-sdk, hmm?
                 ]]
+
+class Poppler__tools (tools.AutoBuild, Poppler):
+    dependencies = [
+        'xzutils',
+        'libtool',
+        'glib',
+        'zlib',
+        'fontconfig',
+        'libjpeg',
+        'libxml2',
+    ]
+    configure_flags = (tools.AutoBuild.configure_flags
+                       + ' --disable-poppler-qt'
+                       + ' --disable-poppler-qt4'
+                       + ' --enable-xpdf-headers'
+                       + ' --disable-gtk-test')


### PR DESCRIPTION
By Issue 5000, optionally using Ghostscript >= 9.20 together with
Extract PDFmark can significantly reduce the disk space required
for building the documentation and the final PDF files.

This pull request makes GUB can use them and reduce the disk space and PDF file size.

It also makes you can use GUB in Ubuntu 16.04 LTS environment.
I've succeeded `make lilypond` clean full building in Ubuntu 16.04 LTS 64 bit environment.

Would you merge this pull request and try following command before next `make lilypond`?

```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```
