### PR TITLE
Fix tools::ghostscript

### DIFF
--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -389,8 +389,6 @@ cd %(builddir)s && sort -u gconfig_-native.h gconfig_-tools.h | grep "^#define" 
                 + ' docdir=%(prefix_dir)s/share/doc/ghostscript/doc '
                 + ' exdir=%(prefix_dir)s/share/doc/ghostscript/examples '
                 )
-    def packaging_suffix_dir (self):
-        return ''
     def install (self):
         tools.AutoBuild.install (self)
         self.system ('mkdir -p %(install_root)s/usr/etc/relocate')

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -349,7 +349,22 @@ class Ghostscript__tools (tools.AutoBuild, Ghostscript_static):
         'libtiff-devel',
         ]
     configure_flags = (tools.AutoBuild.configure_flags
-                       + Ghostscript_static.configure_flags)
+                       + misc.join_lines ('''
+--enable-debug
+--with-drivers=FILES
+--without-pdftoraster
+--disable-fontconfig 
+--disable-gtk
+--disable-cairo
+--without-x
+--disable-cups
+--without-ijs
+--without-omni
+--without-jasper
+--disable-compile-inits
+--with-system-libtiff
+--enable-little-endian
+'''))
     make_flags = Ghostscript_static.make_flags
     def configure (self):
         tools.AutoBuild.configure (self)

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -389,15 +389,6 @@ cd %(builddir)s && sort -u gconfig_-native.h gconfig_-tools.h | grep "^#define" 
                 + ' docdir=%(prefix_dir)s/share/doc/ghostscript/doc '
                 + ' exdir=%(prefix_dir)s/share/doc/ghostscript/examples '
                 )
-    def install (self):
-        tools.AutoBuild.install (self)
-        self.system ('mkdir -p %(install_root)s/usr/etc/relocate')
-        self.dump ('''
-prependdir GS_FONTPATH=$INSTALLER_PREFIX/share/ghostscript/%(version)s/fonts
-prependdir GS_FONTPATH=$INSTALLER_PREFIX/share/gs/fonts
-prependdir GS_LIB=$INSTALLER_PREFIX/share/ghostscript/%(version)s/Resource
-prependdir GS_LIB=$INSTALLER_PREFIX/share/ghostscript/%(version)s/Resource/Init
-''', '%(install_root)s/usr/etc/relocate/gs.reloc')
 
 def test ():
     printf ('Ghostscript.static_version:', Ghostscript.static_version ())


### PR DESCRIPTION
http://lists.gnu.org/archive/html/lilypond-devel/2016-12/msg00025.html
If I understand correctly, I've found out the cause.
Is there the following line in the log file?

GPL Ghostscript 9.20: Can't find initialization file gs_init.ps.

Would you merge this pull request and try following command before next `make lilypond`?

```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```

