### PR TITLE
Fix harfbuzz when system has ICU

### DIFF
--- a/gub/specs/harfbuzz.py
+++ b/gub/specs/harfbuzz.py
@@ -1,3 +1,4 @@
+from gub import misc
 from gub import target
 from gub import tools
 
@@ -9,7 +10,10 @@ class Harfbuzz (target.AutoBuild):
         'glib-devel',
     ]
     configure_flags = (target.AutoBuild.configure_flags
-                       + ' --without-cairo' )
+                       + misc.join_lines ('''
+--without-cairo
+--without-icu
+'''))
 
 class Harfbuzz__tools (tools.AutoBuild, Harfbuzz):
     pass


### PR DESCRIPTION
This patch solves harfbuzz issue.
http://lists.gnu.org/archive/html/lilypond-devel/2016-12/msg00124.html

Would you merge this pull request and try following command before next `make lilypond`?
```
$ git fetch orign
$ git checkout master
$ git merge origin/master
```