### PR TITLE
Process freedesktop.org's permanent move to https

### DIFF
--- a/gub/mirrors.py
+++ b/gub/mirrors.py
@@ -72,7 +72,7 @@ jpeg = 'ftp://ftp.uu.net/graphics/jpeg/jpegsrc.v6b.tar.gz'
 
 freebsd_ports = 'ftp://ftp.uk.freebsd.org/pub/FreeBSD/ports/local-distfiles/lioux/%(name)s-%(version)s.tar.%(format)s'
 
-freedesktop = 'http://%(name)s.freedesktop.org/releases/%(name)s-%(version)s.tar.%(format)s'
+freedesktop = 'https://%(name)s.freedesktop.org/releases/%(name)s-%(version)s.tar.%(format)s'
 
 glibc_deb = 'http://ftp.debian.org/debian/pool/main/g/glibc/%(name)s_%(version)s_%%(package_arch)s.%(format)s'
 

--- a/gub/specs/dbus-glib.py
+++ b/gub/specs/dbus-glib.py
@@ -2,7 +2,7 @@ from gub import build
 from gub import target
 
 class Dbus_glib (target.AutoBuild):
-    source = 'http://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.82.tar.gz'
+    source = 'https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.82.tar.gz'
     dependencies = [
         'dbus',
         'glib',

--- a/gub/specs/dbus.py
+++ b/gub/specs/dbus.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Dbus (target.AutoBuild):
-    source = 'http://dbus.freedesktop.org/releases/dbus/dbus-1.2.14.tar.gz'
+    source = 'https://dbus.freedesktop.org/releases/dbus/dbus-1.2.14.tar.gz'
     dependencies = ['tools::automake', 'tools::pkg-config',
                 ]
     config_cache_overrides = target.AutoBuild.config_cache_overrides + '''

--- a/gub/specs/fixesproto.py
+++ b/gub/specs/fixesproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Fixesproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/fixesproto-4.0.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/fixesproto-4.0.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/harfbuzz.py
+++ b/gub/specs/harfbuzz.py
@@ -3,7 +3,7 @@ from gub import target
 from gub import tools
 
 class Harfbuzz (target.AutoBuild):
-    source = 'http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.0.tar.bz2'
+    source = 'https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.0.tar.bz2'
     dependencies = [
         'tools::bzip2',
         'freetype-devel',

--- a/gub/specs/inputproto.py
+++ b/gub/specs/inputproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Inputproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/inputproto-1.4.4.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/inputproto-1.4.4.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/kbproto.py
+++ b/gub/specs/kbproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Kbproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/kbproto-1.0.3.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/kbproto-1.0.3.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/libpthread-stubs.py
+++ b/gub/specs/libpthread-stubs.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libpthread_stubs (target.AutoBuild):
-    source = 'http://xcb.freedesktop.org/dist/libpthread-stubs-0.1.tar.gz'
+    source = 'https://xcb.freedesktop.org/dist/libpthread-stubs-0.1.tar.gz'
     dependencies = ['tools::libtool']
 
 class Libpthread_stubs__freebsd__x86 (Libpthread_stubs):

--- a/gub/specs/libx11.py
+++ b/gub/specs/libx11.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libx11 (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/lib/libX11-1.1.5.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/lib/libX11-1.1.5.tar.gz'
     dependencies = ['tools::pkg-config', 'libtool', 'inputproto-devel', 'kbproto-devel', 'libxcb-devel', 'xextproto-devel', 'xproto-devel', 'xtrans-devel']
     configure_flags = (target.AutoBuild.configure_flags
                 + ' --disable-xf86bigfont'

--- a/gub/specs/libxau.py
+++ b/gub/specs/libxau.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libxau (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXau-1.0.4.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXau-1.0.4.tar.gz'
     dependencies = ['tools::libtool', 'xproto-devel']
 
 class Libxau__freebsd (Libxau):

--- a/gub/specs/libxcb.py
+++ b/gub/specs/libxcb.py
@@ -3,14 +3,14 @@ from gub import context
 from gub import target
 
 class Libxcb (target.AutoBuild):
-    source = 'http://xcb.freedesktop.org/dist/libxcb-0.9.93.tar.gz'
+    source = 'https://xcb.freedesktop.org/dist/libxcb-0.9.93.tar.gz'
     #1.1.92 removes libxcb-xlib, which libx11-1.1.15 needs?
-    #source = 'http://xcb.freedesktop.org/dist/libxcb-1.1.93.tar.gz'
+    #source = 'https://xcb.freedesktop.org/dist/libxcb-1.1.93.tar.gz'
     '''
 xproto.c:3056: error: conflicting types for 'xcb_get_atom_name_name'
 /home/janneke/vc/gub/target/linux-64/src/libxcb-1.1.93/src/xproto.h:6867: error: previous declaration of 'xcb_get_atom_name_name' was here
 '''
-    #source = 'http://xcb.freedesktop.org/dist/libxcb-1.1.91.tar.gz'
+    #source = 'https://xcb.freedesktop.org/dist/libxcb-1.1.91.tar.gz'
     '''
 xproto.c: In function 'xcb_configure_window_checked':
 xproto.c:2479: error: 'xcb_configure_window_request_t' has no member named 'pad1'

--- a/gub/specs/libxdmcp.py
+++ b/gub/specs/libxdmcp.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Libxdmcp (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXdmcp-1.0.2.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXdmcp-1.0.2.tar.gz'
     dependencies = ['tools::libtool', 'xproto-devel']

--- a/gub/specs/libxext.py
+++ b/gub/specs/libxext.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libxext (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/lib/libXext-1.0.4.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/lib/libXext-1.0.4.tar.gz'
     dependencies = ['libtool', 'libx11-devel']
     configure_flags = (target.AutoBuild.configure_flags
                        + ' --disable-malloc0returnsnull')

--- a/gub/specs/libxfixes.py
+++ b/gub/specs/libxfixes.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Libxfixes (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXfixes-4.0.3.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXfixes-4.0.3.tar.gz'
     dependencies = ['tools::libtool', 'fixesproto-devel', 'libx11-devel', 'libxau-devel', 'libxdmcp-devel']

--- a/gub/specs/libxinerama.py
+++ b/gub/specs/libxinerama.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Libxinerama (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/lib/libXinerama-1.0.3.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/lib/libXinerama-1.0.3.tar.gz'
     dependencies = ['tools::libtool', 'libx11-devel', 'xineramaproto-devel']

--- a/gub/specs/libxrender.py
+++ b/gub/specs/libxrender.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Libxrender (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXrender-0.9.4.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/libXrender-0.9.4.tar.gz'
     dependencies = ['tools::libtool', 'libx11-devel', 'libxdmcp-devel', 'renderproto-devel']
     configure_flags = (target.AutoBuild.configure_flags
                        + ' --disable-malloc0returnsnull')

--- a/gub/specs/renderproto.py
+++ b/gub/specs/renderproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Renderproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/everything/renderproto-0.9.3.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/everything/renderproto-0.9.3.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/xcb-proto.py
+++ b/gub/specs/xcb-proto.py
@@ -1,7 +1,7 @@
 from gub import target
 
 class Xcb_proto (target.AutoBuild):
-    source = 'http://xcb.freedesktop.org/dist/xcb-proto-1.3.tar.gz'
+    source = 'https://xcb.freedesktop.org/dist/xcb-proto-1.3.tar.gz'
     dependencies = [
         'tools::libtool',
 #        'tools::python-2-6',

--- a/gub/specs/xextproto.py
+++ b/gub/specs/xextproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Xextproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/proto/xextproto-7.0.3.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/proto/xextproto-7.0.3.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/xineramaproto.py
+++ b/gub/specs/xineramaproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Xineramaproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/proto/xineramaproto-1.1.2.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/proto/xineramaproto-1.1.2.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/xproto.py
+++ b/gub/specs/xproto.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Xproto (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/proto/xproto-7.0.13.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/proto/xproto-7.0.13.tar.gz'
     dependencies = ['tools::libtool']

--- a/gub/specs/xtrans.py
+++ b/gub/specs/xtrans.py
@@ -1,5 +1,5 @@
 from gub import target
 
 class Xtrans (target.AutoBuild):
-    source = 'http://xorg.freedesktop.org/releases/X11R7.4/src/lib/xtrans-1.2.1.tar.gz'
+    source = 'https://xorg.freedesktop.org/releases/X11R7.4/src/lib/xtrans-1.2.1.tar.gz'
     dependencies = ['tools::libtool', 'xproto']

--- a/sourcefiles/dbus-bus-introspect.xml
+++ b/sourcefiles/dbus-bus-introspect.xml
@@ -1,5 +1,5 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
-"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+"https://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
   <interface name="org.freedesktop.DBus.Introspectable">
     <method name="Introspect">

--- a/web/links.html
+++ b/web/links.html
@@ -35,7 +35,7 @@
       <a href="http://lilypond.org/blog/janneke/gub3-ooo-mingw-cross-build">lilypond.org/blog/janneke/gub3-ooo-mingw-cross-build</a><br>
       <a href="http://openembedded.org">openembedded.org</a><br>
       <a href="http://scratchbox.org">scratchbox.org</a><br>
-      <a href="http://www.freedesktop.org/wiki/Software/sbox2">Scratbox2; sb2</a></br>
+      <a href="https://www.freedesktop.org/wiki/Software/sbox2">Scratbox2; sb2</a></br>
       <a href="http://www.kegel.com/crosstool/">Dan Kegel's crosstool</a><br>
       
     </div>


### PR DESCRIPTION
While trialling with a minimal docker base (having only curl installed as an http client) I encountered 

```
 *** Stage: download (pkg-config, tools)
Running download_url
  ('http://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz', '/home/gub/gub/downloads/pkg-config')
  {}
Traceback (most recent call last):
  File "bin/gub", line 233, in exceptional_build
    build (settings, options, files)
  File "bin/gub", line 199, in build
    specs[name].download ()
  File "bin/../gub/build.py", line 244, in download
    self.source.download ()
  File "bin/../gub/repository.py", line 458, in download
    self.download_url (self.source, self.dir)
  File "bin/../gub/repository.py", line 213, in logged
    return loggedos_func (self.logger, *args, **kwargs)
  File "bin/../gub/loggedos.py", line 52, in func_with_logging
    val = logged_function (logger, func, *args, **kwargs)
  File "bin/../gub/loggedos.py", line 19, in logged_function
    return function (*args, **kwargs)
  File "bin/../gub/misc.py", line 341, in download_url
    raise Exception ('Download failed', result)
Exception: ('Download failed', HTTPError())
```

which appears to be caused by the permanent move of freedesktop.org to https (I suspect that in environments with wget available it works as wget is following redirects whereas curl is not)

```
gub@38980d436626:~/gub$ curl http://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz">here</a>.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at pkg-config.freedesktop.org Port 80</address>
</body></html>
gub@38980d436626:~/gub$ set +ux
gub@38980d436626:~/gub$ curl http://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>301 Moved Permanently</title>
</head><body>
<h1>Moved Permanently</h1>
<p>The document has moved <a href="https://pkg-config.freedesktop.org/releases/pkg-config-0.20.tar.gz">here</a>.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at pkg-config.freedesktop.org Port 80</address>
</body></html>
```

This commit updates all http-based freedesktop.org URLs and URL-patterns in the GUB codebase to https-based ones