### PR TITLE
Fix fontconfig cache failure on MinGW

### DIFF
--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -28,6 +28,8 @@ specified by applications.'''
         'fontconfig-2.12.1-fix-psfont-alias.patch',
         # This patch will not be needed from fontconfig 2.12.2.
         'fontconfig-2.12.1-urw-june-2016.patch',
+        # This patch will not be needed from fontconfig 2.12.2.
+        'fontconfig-2.12.1-fix-FcCacheOffsetValid.patch',
     ]
     #source = 'git://anongit.freedesktop.org/git/fontconfig?branch=master&revision=' + version
     dependencies = ['libtool', 'expat-devel', 'freetype-devel', 'tools::freetype', 'tools::pkg-config', 'tools::bzip2']
@@ -129,9 +131,6 @@ class Fontconfig__mingw (Fontconfig):
                    mode='a')
 
 class Fontconfig__darwin (Fontconfig):
-    patches = Fontconfig.patches + [
-        'fontconfig-2.12.1-mac.patch'
-    ]
     configure_flags = (Fontconfig.configure_flags
                          + ' --with-add-fonts=/Library/Fonts,/System/Library/Fonts ')
     def configure (self):

--- a/gub/specs/fontconfig.py
+++ b/gub/specs/fontconfig.py
@@ -117,6 +117,9 @@ set FONTCONFIG_PATH=$INSTALLER_PREFIX/etc/fonts
              '%(install_prefix)s/etc/fonts/conf.d/98-gub-fonts-dir.conf')
 
 class Fontconfig__mingw (Fontconfig):
+    patches = Fontconfig.patches + [
+        'fontconfig-2.12.1-fix-cache-mingw.patch'
+    ]
     def patch (self):
         Fontconfig.patch (self)
         self.file_sub ([('<cachedir>@FC_CACHEDIR@</cachedir>', '')],

--- a/gub/specs/fonts-texgyre.py
+++ b/gub/specs/fonts-texgyre.py
@@ -2,10 +2,12 @@ from gub import tools
 from gub import build
 
 class Fonts_texgyre (build.BinaryBuild):
-    source = 'http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-2.005otf.zip'
+    source = 'http://www.gust.org.pl/projects/e-foundry/tex-gyre/whole/tg-2.005bas.zip'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/texgyre')
-        self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/texgyre/')
+        self.system ('cp %(srcdir)s/fonts/opentype/public/tex-gyre/*.otf %(install_prefix)s/share/fonts/opentype/texgyre/')
+        self.system ('mkdir -p %(install_prefix)s/share/doc/texgyre')
+        self.system ('cp %(srcdir)s/doc/fonts/tex-gyre/* %(install_prefix)s/share/doc/texgyre/')
     def package (self):
         build.AutoBuild.package (self)
 

--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -13,6 +13,8 @@ class Fonts_urw_core35 (build.BinaryBuild):
         self.system ('cp %(srcdir)s/*.t1 %(install_prefix)s/share/fonts/type1/urw-core35/')
         self.system ('cp %(srcdir)s/*.ttf %(install_prefix)s/share/fonts/truetype/urw-core35/')
         self.system ('cp %(srcdir)s/*.otf %(install_prefix)s/share/fonts/opentype/urw-core35/')
+        self.system ('mkdir -p %(install_prefix)s/share/doc/urw-core35')
+        self.system ('cp %(srcdir)s/COPYING %(srcdir)s/LICENSE %(install_prefix)s/share/doc/urw-core35')
     def package (self):
         build.AutoBuild.package (self)
 

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -109,6 +109,8 @@ sheet music from a high-level description file.'''
         return v
     def install (self):
         target.AutoBuild.install (self)
+        self.system ('cp %(tools_prefix)s/share/doc/texgyre/GUST-FONT-LICENSE.txt %(install_root)s/license/fonts-texgyre')
+        self.system ('cp %(tools_prefix)s/share/doc/urw-core35/LICENSE %(install_root)s/license/fonts-urw-core35')
         # FIXME: This should not be in generic package, for installers only.
         self.installer_install_stuff ()
     def installer_install_stuff (self):

--- a/patches/fontconfig-2.12.1-fix-FcCacheOffsetValid.patch
+++ b/patches/fontconfig-2.12.1-fix-FcCacheOffsetValid.patch
@@ -1,0 +1,51 @@
+From 0e9b2a152729bfd457e656a9258a06cbfdac1bae Mon Sep 17 00:00:00 2001
+From: Akira TAGOH <akira@tagoh.org>
+Date: Mon, 14 Nov 2016 20:14:35 +0900
+Subject: Fix FcCacheOffsetsValid()
+
+Validation fails when the FcValueList contains more than font->num.
+this logic was wrong because font->num contains a number of the elements
+in FcPatternElt but FcValue in FcValueList.
+
+This corrects 7a4a5bd7.
+
+Patch from Tobias Stoeckmann
+
+diff --git a/src/fccache.c b/src/fccache.c
+index 02ec301..6f3c68a 100644
+--- a/src/fccache.c
++++ b/src/fccache.c
+@@ -640,6 +640,7 @@ FcCacheOffsetsValid (FcCache *cache)
+             FcPattern		*font = FcFontSetFont (fs, i);
+             FcPatternElt	*e;
+             FcValueListPtr	 l;
++	    char                *last_offset;
+ 
+             if ((char *) font < base ||
+                 (char *) font > end - sizeof (FcFontSet) ||
+@@ -653,11 +654,17 @@ FcCacheOffsetsValid (FcCache *cache)
+             if (e->values != 0 && !FcIsEncodedOffset(e->values))
+                 return FcFalse;
+ 
+-            for (j = font->num, l = FcPatternEltValues(e); j >= 0 && l; j--, l = FcValueListNext(l))
+-                if (l->next != NULL && !FcIsEncodedOffset(l->next))
+-                    break;
+-            if (j < 0)
+-                return FcFalse;
++	    for (j = 0; j < font->num; j++)
++	    {
++		last_offset = (char *) font + font->elts_offset;
++		for (l = FcPatternEltValues(&e[j]); l; l = FcValueListNext(l))
++		{
++		    if ((char *) l < last_offset || (char *) l > end - sizeof (*l) ||
++			(l->next != NULL && !FcIsEncodedOffset(l->next)))
++			return FcFalse;
++		    last_offset = (char *) l + 1;
++		}
++	    }
+         }
+     }
+ 
+-- 
+cgit v0.10.2
+

--- a/patches/fontconfig-2.12.1-fix-cache-mingw.patch
+++ b/patches/fontconfig-2.12.1-fix-cache-mingw.patch
@@ -1,0 +1,62 @@
+From 7f420d5e0cbc202885c53b6ce4854984464bf831 Mon Sep 17 00:00:00 2001
+From: Masamichi Hosoda <trueroad@trueroad.jp>
+Date: Wed, 11 Jan 2017 20:42:56 +0900
+Subject: [PATCH v2] Bug 99360 - Fix cache file update on MinGW
+
+On Windows, opened or locked files cannot be removed.
+Since fontconfig locked an old cache file while updating the file,
+fontconfig failed to replace the file with updated file on Windows.
+
+This patch makes fontconfig does not lock the old cache file
+while updating it on Windows.
+---
+ src/fcdir.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/src/fcdir.c b/src/fcdir.c
+index fd62a34..c8aaf54 100644
+--- a/src/fcdir.c
++++ b/src/fcdir.c
+@@ -362,7 +362,9 @@ FcDirCacheScan (const FcChar8 *dir, FcConfig *config)
+     if (!dirs)
+ 	goto bail1;
+ 
++#ifndef _WIN32
+     fd = FcDirCacheLock (dir, config);
++#endif
+     /*
+      * Scan the dir
+      */
+@@ -382,7 +384,9 @@ FcDirCacheScan (const FcChar8 *dir, FcConfig *config)
+     FcDirCacheWrite (cache, config);
+ 
+  bail2:
++#ifndef _WIN32
+     FcDirCacheUnlock (fd);
++#endif
+     FcStrSetDestroy (dirs);
+  bail1:
+     FcFontSetDestroy (set);
+@@ -417,7 +421,9 @@ FcDirCacheRescan (const FcChar8 *dir, FcConfig *config)
+     if (!dirs)
+ 	goto bail;
+ 
++#ifndef _WIN32
+     fd = FcDirCacheLock (dir, config);
++#endif
+     /*
+      * Scan the dir
+      */
+@@ -436,7 +442,9 @@ FcDirCacheRescan (const FcChar8 *dir, FcConfig *config)
+     FcDirCacheWrite (new, config);
+ 
+ bail1:
++#ifndef _WIN32
+     FcDirCacheUnlock (fd);
++#endif
+     FcStrSetDestroy (dirs);
+ bail:
+     if (d)
+-- 
+2.8.3
+


### PR DESCRIPTION
This pull request fixes a fontconfig cache issue on Windows.
http://lists.gnu.org/archive/html/lilypond-devel/2017-01/msg00095.html
https://bugs.freedesktop.org/show_bug.cgi?id=99360

The patch has not yet been merged into the fontconfig repository.
However, in order to solve an issue, such as the following, I would like to apply the patch using GUB.
http://lists.gnu.org/archive/html/lilypond-user/2017-02/msg00364.html