### PR TITLE
Update Ghostscript to 9.21

### DIFF
--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -3,8 +3,7 @@ from gub import build
 
 class Fonts_urw_core35 (build.BinaryBuild):
     # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=79bcdfb34fbce12b592cce389fa7a19da6b5b018
-    revision = '79bcdfb34fbce12b592cce389fa7a19da6b5b018'
-    source = 'git://git.ghostscript.com/urw-core35-fonts.git&revision=' + revision
+    source = 'http://lilypond.org/downloads/gub-sources/urw-fonts/urw-core35-fonts-79bcdfb.tar.xz'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
         self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/urw-core35')

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -19,7 +19,7 @@ Supported printers include common dot-matrix, inkjet and laser
 models.'''
 
     exe = ''
-    source = 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs920/ghostscript-9.20.tar.gz'
+    source = 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs921/ghostscript-9.21.tar.xz'
     patches = [
         'ghostscript-9.20-make.patch',
         'ghostscript-9.20-cygwin.patch',
@@ -88,6 +88,7 @@ models.'''
         'libjpeg-devel',
         'libtiff-runtime',
         'tools::pkg-config',
+        'tools::xzutils',
         ]
     def get_build_dependencies (self):
         return ['libtiff-devel']

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -284,7 +284,6 @@ include $(GLSRCDIR)/pcwin.mak
 
 class Ghostscript__freebsd (Ghostscript):
     dependencies = Ghostscript.dependencies + ['libiconv-devel']
-    patches = Ghostscript.patches + ['ghostscript-9.15-freebsd6.patch']
     def configure (self):
         Ghostscript.configure (self)
         if 'linux' in self.settings.build_architecture:

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -21,6 +21,10 @@ models.'''
     exe = ''
     source = 'https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs921/ghostscript-9.21.tar.xz'
     patches = [
+        'ghostscript-9.21-bug697799-1.patch',
+        'ghostscript-9.21-bug697799-2.patch',
+        'ghostscript-9.21-bug697846.patch',
+        'ghostscript-9.21-bug697892.patch',
         'ghostscript-9.20-make.patch',
         'ghostscript-9.20-cygwin.patch',
         'ghostscript-9.15-windows-popen.patch',

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -205,7 +205,7 @@ models.'''
         # obj/mkromfs is needed for --enable-compile-inits but depends on native -liconv.
         self.system ('''
 cd %(builddir)s && mkdir -p %(obj)s
-cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= AUXEXTRALIBS= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf %(obj)s/aux/echogs %(obj)s/aux/genarch %(obj)s/arch.h
+cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= AUXEXTRALIBS= TARGET_ARCH_FILE= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf %(obj)s/aux/echogs %(obj)s/aux/genarch %(obj)s/arch.h
 ''')
         self.fixup_arch ()
         target.AutoBuild.compile (self)

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -205,7 +205,7 @@ models.'''
         # obj/mkromfs is needed for --enable-compile-inits but depends on native -liconv.
         self.system ('''
 cd %(builddir)s && mkdir -p %(obj)s
-cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf %(obj)s/aux/echogs %(obj)s/aux/genarch %(obj)s/arch.h
+cd %(builddir)s && make PATH=/usr/bin:$PATH CC=cc CCAUX=cc C_INCLUDE_PATH= CFLAGS= CPPFLAGS= GCFLAGS= LIBRARY_PATH= AUXEXTRALIBS= OBJ=build-o GLGENDIR=%(obj)s %(obj)s/aux/genconf %(obj)s/aux/echogs %(obj)s/aux/genarch %(obj)s/arch.h
 ''')
         self.fixup_arch ()
         target.AutoBuild.compile (self)

--- a/patches/ghostscript-9.21-bug697799-1.patch
+++ b/patches/ghostscript-9.21-bug697799-1.patch
@@ -1,0 +1,31 @@
+From 4f83478c88c2e05d6e8d79ca4557eb039354d2f3 Mon Sep 17 00:00:00 2001
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Thu, 27 Apr 2017 13:03:33 +0100
+Subject: [PATCH] Bug 697799: have .eqproc check its parameters
+
+The Ghostscript custom operator .eqproc was not check the number or type of
+the parameters it was given.
+---
+ psi/zmisc3.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/psi/zmisc3.c b/psi/zmisc3.c
+index 54b3042..37293ff 100644
+--- a/psi/zmisc3.c
++++ b/psi/zmisc3.c
+@@ -56,6 +56,12 @@ zeqproc(i_ctx_t *i_ctx_p)
+     ref2_t stack[MAX_DEPTH + 1];
+     ref2_t *top = stack;
+ 
++    if (ref_stack_count(&o_stack) < 2)
++        return_error(gs_error_stackunderflow);
++    if (!r_is_array(op - 1) || !r_is_array(op)) {
++        return_error(gs_error_typecheck);
++    }
++
+     make_array(&stack[0].proc1, 0, 1, op - 1);
+     make_array(&stack[0].proc2, 0, 1, op);
+     for (;;) {
+-- 
+2.9.1
+

--- a/patches/ghostscript-9.21-bug697799-2.patch
+++ b/patches/ghostscript-9.21-bug697799-2.patch
@@ -1,0 +1,60 @@
+From 04b37bbce174eed24edec7ad5b920eb93db4d47d Mon Sep 17 00:00:00 2001
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Thu, 27 Apr 2017 13:21:31 +0100
+Subject: [PATCH] Bug 697799: have .rsdparams check its parameters
+
+The Ghostscript internal operator .rsdparams wasn't checking the number or
+type of the operands it was being passed. Do so.
+---
+ psi/zfrsd.c | 22 +++++++++++++++-------
+ 1 file changed, 15 insertions(+), 7 deletions(-)
+
+diff --git a/psi/zfrsd.c b/psi/zfrsd.c
+index 191107d..950588d 100644
+--- a/psi/zfrsd.c
++++ b/psi/zfrsd.c
+@@ -49,13 +49,20 @@ zrsdparams(i_ctx_t *i_ctx_p)
+     ref *pFilter;
+     ref *pDecodeParms;
+     int Intent = 0;
+-    bool AsyncRead;
++    bool AsyncRead = false;
+     ref empty_array, filter1_array, parms1_array;
+     uint i;
+-    int code;
++    int code = 0;
++
++    if (ref_stack_count(&o_stack) < 1)
++        return_error(gs_error_stackunderflow);
++    if (!r_has_type(op, t_dictionary) && !r_has_type(op, t_null)) {
++        return_error(gs_error_typecheck);
++    }
+ 
+     make_empty_array(&empty_array, a_readonly);
+-    if (dict_find_string(op, "Filter", &pFilter) > 0) {
++    if (r_has_type(op, t_dictionary)
++        && dict_find_string(op, "Filter", &pFilter) > 0) {
+         if (!r_is_array(pFilter)) {
+             if (!r_has_type(pFilter, t_name))
+                 return_error(gs_error_typecheck);
+@@ -94,12 +101,13 @@ zrsdparams(i_ctx_t *i_ctx_p)
+                 return_error(gs_error_typecheck);
+         }
+     }
+-    code = dict_int_param(op, "Intent", 0, 3, 0, &Intent);
++    if (r_has_type(op, t_dictionary))
++        code = dict_int_param(op, "Intent", 0, 3, 0, &Intent);
+     if (code < 0 && code != gs_error_rangecheck) /* out-of-range int is ok, use 0 */
+         return code;
+-    if ((code = dict_bool_param(op, "AsyncRead", false, &AsyncRead)) < 0
+-        )
+-        return code;
++    if (r_has_type(op, t_dictionary))
++        if ((code = dict_bool_param(op, "AsyncRead", false, &AsyncRead)) < 0)
++            return code;
+     push(1);
+     op[-1] = *pFilter;
+     if (pDecodeParms)
+-- 
+2.9.1
+

--- a/patches/ghostscript-9.21-bug697846.patch
+++ b/patches/ghostscript-9.21-bug697846.patch
@@ -1,0 +1,45 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Wed, 3 May 2017 11:05:45 +0000 (+0100)
+Subject: Bug 697846: revision to commit 4f83478c88 (.eqproc)
+X-Git-Url: http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff_plain;h=57f20719
+
+Bug 697846: revision to commit 4f83478c88 (.eqproc)
+
+When using the "DELAYBIND" feature, it turns out that .eqproc can be called with
+parameters that are not both procedures. In this case, it turns out, the
+expectation is for the operator to return 'false', rather than throw an error.
+---
+
+diff --git a/psi/zmisc3.c b/psi/zmisc3.c
+index 37293ff..3f01d39 100644
+--- a/psi/zmisc3.c
++++ b/psi/zmisc3.c
+@@ -38,6 +38,15 @@ zcliprestore(i_ctx_t *i_ctx_p)
+     return gs_cliprestore(igs);
+ }
+ 
++static inline bool
++eqproc_check_type(ref *r)
++{
++    return r_has_type(r, t_array)
++           || r_has_type(r, t_mixedarray)
++           || r_has_type(r, t_shortarray)
++           || r_has_type(r, t_oparray);
++}
++
+ /* <proc1> <proc2> .eqproc <bool> */
+ /*
+  * Test whether two procedures are equal to depth 10.
+@@ -58,8 +67,10 @@ zeqproc(i_ctx_t *i_ctx_p)
+ 
+     if (ref_stack_count(&o_stack) < 2)
+         return_error(gs_error_stackunderflow);
+-    if (!r_is_array(op - 1) || !r_is_array(op)) {
+-        return_error(gs_error_typecheck);
++    if (!eqproc_check_type(op -1) || !eqproc_check_type(op)) {
++        make_false(op - 1);
++        pop(1);
++        return 0;
+     }
+ 
+     make_array(&stack[0].proc1, 0, 1, op - 1);

--- a/patches/ghostscript-9.21-bug697892.patch
+++ b/patches/ghostscript-9.21-bug697892.patch
@@ -1,0 +1,39 @@
+From: Chris Liddell <chris.liddell@artifex.com>
+Date: Thu, 11 May 2017 13:07:48 +0000 (+0100)
+Subject: Bug 697892: fix check for op stack underflow.
+X-Git-Url: http://git.ghostscript.com/?p=ghostpdl.git;a=commitdiff_plain;h=ccfd2c75
+
+Bug 697892: fix check for op stack underflow.
+
+In the original fix, I used the wrong method to check for stack underflow, this
+is using the correct method.
+---
+
+diff --git a/psi/zfrsd.c b/psi/zfrsd.c
+index 950588d..9c035b9 100644
+--- a/psi/zfrsd.c
++++ b/psi/zfrsd.c
+@@ -54,8 +54,7 @@ zrsdparams(i_ctx_t *i_ctx_p)
+     uint i;
+     int code = 0;
+ 
+-    if (ref_stack_count(&o_stack) < 1)
+-        return_error(gs_error_stackunderflow);
++    check_op(1);
+     if (!r_has_type(op, t_dictionary) && !r_has_type(op, t_null)) {
+         return_error(gs_error_typecheck);
+     }
+diff --git a/psi/zmisc3.c b/psi/zmisc3.c
+index 3f01d39..43803b5 100644
+--- a/psi/zmisc3.c
++++ b/psi/zmisc3.c
+@@ -65,8 +65,7 @@ zeqproc(i_ctx_t *i_ctx_p)
+     ref2_t stack[MAX_DEPTH + 1];
+     ref2_t *top = stack;
+ 
+-    if (ref_stack_count(&o_stack) < 2)
+-        return_error(gs_error_stackunderflow);
++    check_op(2);
+     if (!eqproc_check_type(op -1) || !eqproc_check_type(op)) {
+         make_false(op - 1);
+         pop(1);


### PR DESCRIPTION
Ghostscript 9.20 has PNG transparency problem.
http://lists.gnu.org/archive/html/bug-lilypond/2016-12/msg00012.html
https://bugs.ghostscript.com/show_bug.cgi?id=697423

However, on FreeBSD 32 bit, both Ghostscript 9.20 and 9.21 crash.
So only for FreeBSD 32 bit, Ghostscript 9.15 is used.