### PR TITLE
www.very-clever.com disappeared - update texi2html URL

### DIFF
--- a/gub/specs/texi2html.py
+++ b/gub/specs/texi2html.py
@@ -2,4 +2,4 @@ from gub import tools
 
 class Texi2html__tools (tools.AutoBuild):
     #source = 'http://lilypond.org/vc/texi2html.git&branch=master'
-    source = 'http://www.very-clever.com/download/nongnu/texi2html/texi2html-1.82.tar.gz'
+    source = 'http://download.savannah.gnu.org/releases/texi2html/texi2html-1.82.tar.gz'


### PR DESCRIPTION
to its location discovered via http://www.nongnu.org/texi2html/texi2html-old.html