### PR TITLE
Change fonts-ipafont download site

### DIFF
--- a/gub/specs/fonts-ipafont.py
+++ b/gub/specs/fonts-ipafont.py
@@ -2,10 +2,10 @@ from gub import tools
 from gub import build
 
 class Fonts_ipafont (build.BinaryBuild):
-    source = 'http://download.forest.impress.co.jp/pub/library/i/ipafont/10483/IPAfont00303.zip'
+    source = 'http://mirrors.ctan.org/fonts/ipaex.zip'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/opentype/ipafont')
-        self.system ('cp %(srcdir)s/IPAfont00303/*.ttf %(install_prefix)s/share/fonts/opentype/ipafont/')
+        self.system ('cp %(srcdir)s/ipaex/*.ttf %(install_prefix)s/share/fonts/opentype/ipafont/')
     def package (self):
         build.AutoBuild.package (self)
 


### PR DESCRIPTION
It seems that IPAfont download URL has been changed since June 2016.

http://download.forest.impress.co.jp/pub/library/i/ipafont/10483/IPAfont00303.zip
->
http://dforest.watch.impress.co.jp/library/i/ipafont/10483/IPAfont00303.zip

However, there is a possibility
that it will be changed again by Impress Forest.
So this commit makes GUB downloads it
from CTAN instead of Impress Forest site.