### PR TITLE
Update urw otf 20170727

### DIFF
--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -3,8 +3,7 @@ from gub import build
 
 class Fonts_urw_core35 (build.BinaryBuild):
     # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=91edd6ece36e84a1c6d63a1cf63a1a6d84bd443a
-    revision = '91edd6ece36e84a1c6d63a1cf63a1a6d84bd443a'
-    source = 'git://git.ghostscript.com/urw-core35-fonts.git&revision=' + revision
+    source = 'http://lilypond.org/downloads/gub-sources/urw-fonts/urw-core35-fonts-91edd6e.tar.xz'
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
         self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/urw-core35')

--- a/gub/specs/fonts-urw-core35.py
+++ b/gub/specs/fonts-urw-core35.py
@@ -2,8 +2,9 @@ from gub import tools
 from gub import build
 
 class Fonts_urw_core35 (build.BinaryBuild):
-    # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=79bcdfb34fbce12b592cce389fa7a19da6b5b018
-    source = 'http://lilypond.org/downloads/gub-sources/urw-fonts/urw-core35-fonts-79bcdfb.tar.xz'
+    # http://git.ghostscript.com/?p=urw-core35-fonts.git;a=commit;h=91edd6ece36e84a1c6d63a1cf63a1a6d84bd443a
+    revision = '91edd6ece36e84a1c6d63a1cf63a1a6d84bd443a'
+    source = 'git://git.ghostscript.com/urw-core35-fonts.git&revision=' + revision
     def install (self):
         self.system ('mkdir -p %(install_prefix)s/share/fonts/type1/urw-core35')
         self.system ('mkdir -p %(install_prefix)s/share/fonts/truetype/urw-core35')


### PR DESCRIPTION
URW++ has been released URW++ core 35 fonts 2017-07-27.
It has some bugfixes.

Issue 5163 can handle URW++ core 35 fonts 2017-07-20 and above.

Would you upload
https://drive.google.com/file/d/0ByGBX3PDrqjsc0VmQlRlaDdOZUk/view?usp=sharing
file as
http://lilypond.org/downloads/gub-sources/urw-fonts/urw-core35-fonts-91edd6e.tar.xz
before merging this PR?
