### PR TITLE
Issue 5177: Update lilypad to 0.1.3.0

### DIFF
--- a/gub/specs/lilypad.py
+++ b/gub/specs/lilypad.py
@@ -2,8 +2,8 @@ from gub import misc
 from gub import target
 
 class LilyPad (target.AutoBuild):
-    source = 'http://lilypond.org/downloads/gub-sources/lilypad/lilypad-0.1.2.0-src.tar.bz2'
-    dependencies = [ 'tools::automake' ]
+    source = 'http://lilypond.org/downloads/gub-sources/lilypad/lilypad-0.1.3.0-src.tar.xz'
+    dependencies = [ 'tools::automake', 'tools::xzutils' ]
     destdir_install_broken = True
     license_files = ['']
 


### PR DESCRIPTION
This pull request fixes Issue 5177.
https://sourceforge.net/p/testlilyissues/issues/5177/

Would you merge it and upload
https://drive.google.com/file/d/0ByGBX3PDrqjsZkdGd3pWNjlNXzA/view?usp=sharing
as
http://lilypond.org/downloads/gub-sources/lilypad/lilypad-0.1.3.0-src.tar.xz
?
