### PR TITLE
Glib patch

### DIFF
--- a/gub/gup.py
+++ b/gub/gup.py
@@ -202,7 +202,7 @@ class FileManager:
             if not f or f.endswith ('/'):
                 continue
             try:
-                del self._file_package_db[f]
+                del self._file_package_db[str(f)]
             except:
                 printf ('db delete failing for ', f)
         del self._package_file_db[name]

--- a/gub/specs/darwin/cross/gcc.py
+++ b/gub/specs/darwin/cross/gcc.py
@@ -5,7 +5,7 @@ from gub import loggedos
 from gub import cross
 
 class Gcc__darwin (cross_gcc.Gcc):
-    dependencies = ['odcctools']
+    dependencies = ['tools::gmp', 'tools::mpfr', 'tools::mpc', 'odcctools']
     patches = cross_gcc.Gcc.patches + [
         'gcc-4.8.2-darwin-fixinc.patch',
         'gcc-4.8.2-darwin-libgcc.patch',

--- a/gub/specs/darwin/odcctools.py
+++ b/gub/specs/darwin/odcctools.py
@@ -12,7 +12,7 @@ class Odcctools (cross.AutoBuild): #skews dependencies:, build.SdkBuild):
     source = 'http://lilypond.org/gub/download/odcctools-iphone-dev/odcctools-iphone-dev-278.tar.gz'
     patches = ['odcctools-r211-word.patch',
                'odcctools-config-Wno-long-double.patch']
-    dependencies = ['darwin-sdk', 'tools::flex', 'tools::automake']
+    dependencies = ['darwin-sdk', 'tools::bison', 'tools::flex', 'tools::automake']
     def __init__ (self, settings, source):
         cross.AutoBuild.__init__ (self, settings, source)
         if 'x86_64-linux' in self.settings.build_architecture:

--- a/gub/specs/ghostscript.py
+++ b/gub/specs/ghostscript.py
@@ -302,7 +302,7 @@ class Ghostscript__freebsd (Ghostscript):
 class Ghostscript__freebsd__x86 (Ghostscript__freebsd):
     # ***FIXME*** Ghostscript 9.20 for freebsd-x86 raises seg fault.
     # So we use Ghostscript 9.15.
-    source = 'http://downloads.ghostscript.com/public/old-gs-releases/ghostscript-9.15.tar.gz'
+    source = 'https://ftp.osuosl.org/pub/blfs/conglomeration/ghostscript/ghostscript-9.15.tar.bz2'
     patches = [
         'ghostscript-9.15-make.patch',
         'ghostscript-9.15-cygwin.patch',

--- a/gub/specs/git.py
+++ b/gub/specs/git.py
@@ -13,7 +13,7 @@ class Git (target.AutoBuild):
     make_flags = '''V=1 NO_PERL=NoThanks'''
 
 class Git__tools (tools.AutoBuild, Git):
-    dependencies = ['curl', 'expat', 'zlib']
+    dependencies = ['curl', 'expat', 'zlib', 'tools::gettext']
     configure_flags = (tools.AutoBuild.configure_flags
                        + ' --without-openssl'
                        + ' --without-tcltk'

--- a/gub/specs/glib.py
+++ b/gub/specs/glib.py
@@ -58,6 +58,9 @@ class Glib__freebsd (Glib):
     source = 'http://ftp.gnome.org/pub/GNOME/sources/glib/2.38/glib-2.38.2.tar.xz'
 
 class Glib__tools (tools.AutoBuild, Glib):
+    patches = Glib.patches + [
+        'glib-2.44.1-suppress-string-format-warning.patch',
+    ]
     dependencies = [
             'gettext',
             'libtool',

--- a/gub/specs/glibc.py
+++ b/gub/specs/glibc.py
@@ -42,6 +42,7 @@ to *not* look in /.
 class Glibc (target.AutoBuild, cross.AutoBuild):
     source = 'http://lilypond.org/downloads/gub-sources/glibc/glibc-2.3-20070416.tar.bz2'
     patches = [
+        'glibc-allow-make4.patch',
         'glibc-2.3-powerpc-initfini.patch',
         'glibc-2.3-powerpc-socket-weakalias.patch',
         'glibc-2.3-powerpc-lround-weakalias.patch',

--- a/gub/specs/libpng.py
+++ b/gub/specs/libpng.py
@@ -2,7 +2,7 @@ from gub import target
 from gub import tools 
 
 class Libpng (target.AutoBuild):
-    source = 'http://sourceforge.net/projects/libpng/files/libpng12/1.2.56/libpng-1.2.56.tar.xz'
+    source = 'https://sourceforge.net/projects/libpng/files/libpng12/older-releases/1.2.56/libpng-1.2.56.tar.xz'
     dependencies = [
         'zlib-devel',
         'tools::autoconf',

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -262,6 +262,7 @@ class LilyPond__darwin__ppc (LilyPond__darwin):
 
 class LilyPond_base (target.AutoBuild):
     source = LilyPond.source
+    branch = LilyPond.branch
     install_after_build = False
     ghostscript_version = ghostscript.Ghostscript.static_version ()
     def __init__ (self, settings, source):

--- a/gub/specs/make.py
+++ b/gub/specs/make.py
@@ -4,6 +4,7 @@ from gub import tools
 
 class Make_make__tools (tools.AutoBuild):
     source = 'http://ftp.gnu.org/pub/gnu/make/make-3.81.tar.gz'
+    patches = [ 'make_glob2.patch']
     def __init__ (self, settings, source):
         tools.AutoBuild.__init__ (self, settings, source)
         self.source._unpack = self.source._unpack_promise_well_behaved

--- a/patches/glib-2.44.1-suppress-string-format-warning.patch
+++ b/patches/glib-2.44.1-suppress-string-format-warning.patch
@@ -1,0 +1,36 @@
+From 6e31702eec5ced2d9fd8335aadbd1d450d67c459 Mon Sep 17 00:00:00 2001
+From: Federico Bruni <fede@inventati.org>
+Date: Fri, 5 Oct 2018 17:45:20 +0200
+Subject: [PATCH] gdate: Suppress string format literal warning
+
+This patch merges two related commits upstream:
+
+https://github.com/GNOME/glib/commit/0817af40e8c74c721c30f6ef482b1f53d12044c7
+
+https://github.com/GNOME/glib/commit/8cdbc7fb2c8c876902e457abe46ee18a0b134486
+---
+ glib/gdate.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/glib/gdate.c b/glib/gdate.c
+index 670f7aa5f..63684a905 100644
+--- a/glib/gdate.c
++++ b/glib/gdate.c
+@@ -2439,6 +2439,9 @@ win32_strftime_helper (const GDate     *d,
+  *
+  * Returns: number of characters written to the buffer, or 0 the buffer was too small
+  */
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wformat-nonliteral"
++
+ gsize     
+ g_date_strftime (gchar       *s, 
+                  gsize        slen, 
+@@ -2549,3 +2552,4 @@ g_date_strftime (gchar       *s,
+   return retval;
+ #endif
+ }
++#pragma GCC diagnostic pop
+-- 
+2.17.1
+

--- a/patches/glibc-allow-make4.patch
+++ b/patches/glibc-allow-make4.patch
@@ -1,0 +1,11 @@
+--- old/configure	2018-07-08 16:22:39.141946102 +0200
++++ new/configure	2018-07-08 16:23:27.781477977 +0200
+@@ -4154,7 +4154,7 @@
+   ac_prog_version=`$MAKE --version 2>&1 | sed -n 's/^.*GNU Make[^0-9]*\([0-9][0-9.]*\).*$/\1/p'`
+   case $ac_prog_version in
+     '') ac_prog_version="v. ?.??, bad"; ac_verc_fail=yes;;
+-    3.79* | 3.[89]*)
++    3.79* | 3.[89]* | 4.[0-9.]*)
+        ac_prog_version="$ac_prog_version, ok"; ac_verc_fail=no;;
+     *) ac_prog_version="$ac_prog_version, bad"; ac_verc_fail=yes;;
+

--- a/patches/make_glob2.patch
+++ b/patches/make_glob2.patch
@@ -1,0 +1,77 @@
+diff -Naur old/configure new/configure
+--- old/configure       2006-04-01 08:40:00.000000000 +0200
++++ new/configure       2018-07-17 22:53:07.611101819 +0200
+@@ -13619,10 +13619,9 @@
+ #include <glob.h>
+ #include <fnmatch.h>
+
+-#define GLOB_INTERFACE_VERSION 1
+ #if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
+ # include <gnu-versions.h>
+-# if _GNU_GLOB_INTERFACE_VERSION == GLOB_INTERFACE_VERSION
++# if _GNU_GLOB_INTERFACE_VERSION == 1 || _GNU_GLOB_INTERFACE_VERSION == 2
+    gnu glob
+ # endif
+ #endif
+diff -Naur old/configure.in new/configure.in
+--- old/configure.in    2006-04-01 08:36:40.000000000 +0200
++++ new/configure.in    2018-07-17 22:51:33.679953018 +0200
+@@ -351,10 +351,9 @@
+ #include <glob.h>
+ #include <fnmatch.h>
+
+-#define GLOB_INTERFACE_VERSION 1
+ #if !defined _LIBC && defined __GNU_LIBRARY__ && __GNU_LIBRARY__ > 1
+ # include <gnu-versions.h>
+-# if _GNU_GLOB_INTERFACE_VERSION == GLOB_INTERFACE_VERSION
++# if _GNU_GLOB_INTERFACE_VERSION == 1 || _GNU_GLOB_INTERFACE_VERSION == 2
+    gnu glob
+ # endif
+ #endif
+diff -Naur old/dir.c new/dir.c
+--- old/dir.c   2006-02-11 23:16:04.000000000 +0100
++++ new/dir.c   2018-07-17 22:56:50.513180032 +0200
+@@ -1194,6 +1194,32 @@
+ }
+ #endif
+
++/* Similarly for lstat.  */
++#if !defined(lstat) && !defined(WINDOWS32) || defined(VMS)
++# ifndef VMS
++#  ifndef HAVE_SYS_STAT_H
++int lstat (const char *path, struct stat *sbuf);
++#  endif
++# else
++    /* We are done with the fake lstat.  Go back to the real lstat */
++#   ifdef lstat
++#     undef lstat
++#   endif
++# endif
++# define local_lstat lstat
++#elif defined(WINDOWS32)
++/* Windows doesn't support lstat().  */
++# define local_lstat local_stat
++#else
++static int
++local_lstat (const char *path, struct stat *buf)
++{
++  int e;
++  EINTRLOOP (e, lstat (path, buf));
++  return e;
++}
++#endif
++
+ void
+ dir_setup_glob (glob_t *gl)
+ {
+@@ -1201,9 +1227,8 @@
+   gl->gl_opendir = open_dirstream;
+   gl->gl_readdir = read_dirstream;
+   gl->gl_closedir = ansi_free;
++  gl->gl_lstat = local_lstat;
+   gl->gl_stat = local_stat;
+-  /* We don't bother setting gl_lstat, since glob never calls it.
+-     The slot is only there for compatibility with 4.4 BSD.  */
+ }
+
+ void


### PR DESCRIPTION
This patch allows to run `make bootstrap` successfully on Fedora 28, which has gcc version 8.1.1

As you can see, it's built on top of PR #46 (still to be merged)

Issue on LilyPond tracker:
https://sourceforge.net/p/testlilyissues/issues/5424/