### PR TITLE
Download bzip2 source from Web Archive.

### DIFF
--- a/gub/specs/bzip2.py
+++ b/gub/specs/bzip2.py
@@ -2,7 +2,7 @@ from gub import tools
 from gub import target
 
 class Bzip2 (target.MakeBuild):
-    source = 'http://www.bzip.org/1.0.5/bzip2-1.0.5.tar.gz'
+    source = 'https://web.archive.org/web/20170824030156/http://www.bzip.org/1.0.5/bzip2-1.0.5.tar.gz'
     compile_flags = ''' -f Makefile-libbz2_so CC='%(toolchain_prefix)sgcc %(target_gcc_flags)s -fno-stack-protector' '''
     install_flags = (target.MakeBuild.install_flags
                      + ' PREFIX=%(install_prefix)s')
@@ -13,7 +13,7 @@ class Bzip2 (target.MakeBuild):
         self.system ('cd %(install_prefix)s/bin && rm -f bzless bzfgrep bzegrep bzcmp')
 
 class Bzip2__tools (tools.MakeBuild):
-    source = 'http://www.bzip.org/1.0.5/bzip2-1.0.5.tar.gz'
+    source = 'https://web.archive.org/web/20170824030156/http://www.bzip.org/1.0.5/bzip2-1.0.5.tar.gz'
     compile_flags = ' -f Makefile-libbz2_so'
     install_flags = (tools.MakeBuild.install_flags
                      + ' PREFIX=%(install_prefix)s')


### PR DESCRIPTION
bzip.org domain has been abandoned since August 2018, see:
https://sourceforge.net/p/testlilyissues/issues/5417/