### PR TITLE
fontconfig: Avoid access of fonts outside of gub.

### DIFF
--- a/gub/installer.py
+++ b/gub/installer.py
@@ -224,7 +224,8 @@ class Installer (context.RunnableContext):
             'share/mkspecs',
             'share/terminfo',
 # GUB's internal fonts directory settings
-            'etc/fonts/conf.d/98-gub-fonts-dir.conf',
+            'etc/fonts-gub',
+            'var/cache/fontconfig-gub'
             ]
 
         # FIXME: why are we removing these, we need these in a root image.

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -125,19 +125,12 @@ sheet music from a high-level description file.'''
                      locals ())
 
         self.system ('mkdir -p %(install_prefix)s/etc/fonts/')
-        self.dump ('''
+        self.dump ('''\
 <fontconfig>
-<selectfont>
- <rejectfont>
- <pattern>
-  <patelt name="scalable"><bool>false</bool></patelt>
- </pattern>
- </rejectfont>
-</selectfont>
-
-<cachedir>~/.lilypond-fonts.cache-2</cachedir>
+  <cachedir>~/.lilypond-fonts.cache-2</cachedir>
 </fontconfig>
-''', '%(install_prefix)s/etc/fonts/local.conf', 'w', locals ())
+''',
+            '%(install_prefix)s/etc/fonts/local.conf', 'w', locals ())
 
 class LilyPond__smart (LilyPond__simple):
     configure_binary = '%(srcdir)s/smart-configure.sh'
@@ -295,6 +288,9 @@ class LilyPond_base (target.AutoBuild):
         return 'ulimit -m 524288 && ulimit -d 524288 && ulimit -v 1048576'
     @context.subst_method
     def doc_relocation (self):
+        # These environment variables control lilypond while being run
+        # within gub to build documentation.  In particular, we use a
+        # special fontconfig setup that doesn't use fonts outside of gub.
         return misc.join_lines ('''
 LILYPOND_EXTERNAL_BINARY=%(system_prefix)s/bin/lilypond
 PATH=%(tools_prefix)s/bin:%(system_prefix)s/bin:$PATH
@@ -302,6 +298,8 @@ MALLOC_CHECK_=2
 LD_LIBRARY_PATH=%(tools_prefix)s/lib:%(system_prefix)s/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 GS_FONTPATH=%(system_prefix)s/share/ghostscript/%(ghostscript_version)s/fonts:%(system_prefix)s/share/gs/fonts
 GS_LIB=%(system_prefix)s/share/ghostscript/%(ghostscript_version)s/Resource/Init:%(system_prefix)s/share/ghostscript/%(ghostscript_version)s/Resource
+FONTCONFIG_FILE=%(system_prefix)s/etc/fonts-gub/fonts.conf
+FONTCONFIG_PATH=%(tools_prefix)s/etc/fonts-gub
 ''')
     compile_command = ('%(doc_limits)s '
                 '&& %(doc_relocation)s '

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -284,7 +284,7 @@ class LilyPond_base (target.AutoBuild):
     @context.subst_method
     def doc_limits (self):
         if '64' in self.settings.build_platform:
-            return 'ulimit -m 524288 && ulimit -d 524288 && ulimit -v 2097152 '
+            return 'ulimit -m 1048576 && ulimit -d 1048576 && ulimit -v 3145728'
         return 'ulimit -m 524288 && ulimit -d 524288 && ulimit -v 1048576'
     @context.subst_method
     def doc_relocation (self):


### PR DESCRIPTION
Note that this commit needs lilypond issue #5450 so that we can set up
gub-specific fontconfig configuration files.  As a consequence you can't
test older lilypond versions anymore without patching the created file
`.../target/.../root/usr/etc/relocate/fontconfig.reloc`, replacing `set?`
with `set` (this undoes the use of a special fontconfig setup).

Another minor change is that we no longer generate file
`98-gub-fonts-dir.conf` but `08-gub-fonts-dir.conf`, following fontconfig's
recommendation of include file names.