### PR TITLE
imagemagick.py: Fix include directory order.

### DIFF
--- a/gub/specs/imagemagick.py
+++ b/gub/specs/imagemagick.py
@@ -24,6 +24,22 @@ class ImageMagick__tools (tools.AutoBuild):
 --without-magick-plus-plus
 --without-perl
 '''))
+    # Setting `CFLAGS' is not sufficient since ImageMagick's `configure'
+    # script prepends stuff for libraries like libpng to `CFLAGS'.  We thus
+    # explicitly set `INCLUDES' (as documented in the automake info file) to
+    # ensure that the path to gub's header files comes first.
+    #
+    # However, there seems to be a bug (or a feature) in at least gcc 4.8.5:
+    # Directories in the environment variable `C_INCLUDE_PATH' are processed
+    # similar to `-isystem' arguments, this is, they are handled after `-I'
+    # options but before standard system directories.  Alas, if a directory
+    # `foo' appears in both `C_INCLUDE_PATH' and as an argument to `-I', the
+    # latter is obviously ignored.  For this reason we have to unset
+    # `C_INCLUDE_PATH' (which is set by gub) to really get gub's C header
+    # directory first.
+    make_flags = (tools.AutoBuild.make_flags
+                  + ' INCLUDES=-I%(tools_prefix)s/include '
+                  + ' C_INCLUDE_PATH=')
 
 class ImageMagick__tools__autoupdate (ImageMagick__tools):
     def autoupdate (self):


### PR DESCRIPTION
On my openSUSE Leap 42.3 GNU/Linux box, a much newer libpng version than the
one in gub is installed.  Similarly, gub's ImageMagick version is quite old,
not coping with newer libpng versions; in particular, it expects that
FARDATA is defined in `png.h`, which has been removed in newer versions.

Finding the bug (namely, why `/usr/include/png.h` was used inspite of
properly adding a `-I` command line parameter to gcc) was tricky, since
manual compilation always succeeded.  It took me some hours to find out the
strange behaviour of the `C_INCLUDE_PATH` environment variable – `strace`
was my friend...