### PR TITLE
lilypond-test depends on tools::rsync

### DIFF
--- a/gub/specs/lilypond-test.py
+++ b/gub/specs/lilypond-test.py
@@ -17,6 +17,7 @@ class LilyPond_test (lilypond.LilyPond_base):
                 'tools::fonts-luximono',
                 'tools::fonts-ipafont',
                 'tools::fonts-gnufreefont',
+                'tools::rsync',
                 ])
     @context.subst_method
     def test_ball (self):


### PR DESCRIPTION
Add missing rsync dependency to lilypond-test 