### PR TITLE
Use generic Python database modules.

### DIFF
--- a/gub/2/db.py
+++ b/gub/2/db.py
@@ -1,13 +1,4 @@
-# Get a simple database module  -- gdbm is not generally available
+# Get a simple database module.
 
-import dbhash as bsd
-try:
-    import dbm as ndbm
-except:
-    ndbm = bsd
-try:
-    import gdbm as gnu
-except:
-    gnu = ndbm
-
-db = gnu
+# https://docs.python.org/2/library/anydbm.html
+import anydbm as db

--- a/gub/3/db.py
+++ b/gub/3/db.py
@@ -1,13 +1,4 @@
-# Get a simple database module  -- gdbm is not generally available
+# Get a simple database module.
 
-import dbm.gnu as gnu
-try:
-    import dbm.bsd as bsd
-except:
-    bsd = gnu
-try:
-    import dbm.ndbm as ndbm
-except:
-    ndbm = bsd
-
-db = gnu
+# https://docs.python.org/3/library/dbm.html
+import dbm as db


### PR DESCRIPTION
The existing imports used for databases do not work on all common systems (e.g., macOS). By using the generic interfaces, Python will choose the fastest available database implementation, falling back to the internal "dumb" implementation as a last resort.

The shortcomings of the current import were brought to my attention upon receiving the following error message on macOS.
```shell
$ bin/gub --help    
Traceback (most recent call last):
  File "bin/gub", line 42, in <module>
    from gub import buildrunner
  File "bin/../gub/buildrunner.py", line 29, in <module>
    from gub import cross
  File "bin/../gub/cross.py", line 10, in <module>
    from gub import repository
  File "bin/../gub/repository.py", line 41, in <module>
    from gub.db import db
  File "bin/../gub/2/db.py", line 3, in <module>
    import dbhash as bsd
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/dbhash.py", line 7, in <module>
    import bsddb
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/bsddb/__init__.py", line 67, in <module>
    import _bsddb
ImportError: No module named _bsddb
```
Further, the `bsddb` module in question has been deprecated since Python 2.6 and was removed in Python 3 ([reference](https://docs.python.org/2/library/bsddb.html)), so this should also help with moving to newer versions of Python.