### PR TITLE
Enable compiling librestrict on macOS.

### DIFF
--- a/librestrict/alias.h
+++ b/librestrict/alias.h
@@ -1,0 +1,20 @@
+/**
+ * alias.h
+ *
+ * Darwin does not support alias attributes.
+ * This header defines a 'safe' (i.e., platform-agnostic) way to create aliases.
+ */
+
+/* Create a safe alias for NAME accessible via ALIASNAME. */
+#define safe_alias(name, aliasname) _safe_alias(name, aliasname)
+
+/* Darwin does not support alias attributes. */
+#ifndef __APPLE__
+#define _safe_alias(name, aliasname) \
+        extern __typeof (name) aliasname __attribute__ ((alias (#name)))
+#else
+#define _safe_alias(name, aliasname) \
+        __asm__(".globl _" #aliasname); \
+        __asm__(".set _" #aliasname ", _" #name); \
+        extern __typeof(name) aliasname
+#endif

--- a/librestrict/restrict-exec.c
+++ b/librestrict/restrict-exec.c
@@ -7,6 +7,7 @@
 #include <sys/syscall.h>
 #include <unistd.h>
 
+#include "alias.h"
 #include "restrict.c"
 
 /*
@@ -31,4 +32,4 @@ __execve (char const *file_name, char *const argv[], char *const envp[])
   return sys_execve (file_name, argv, envp);
 }
 
-int execve (char const *file_name, char *const argv[], char *const envp[])  __attribute__ ((alias ("__execve")));
+safe_alias (__execve, execve);

--- a/librestrict/restrict-open.c
+++ b/librestrict/restrict-open.c
@@ -7,6 +7,7 @@
 #include <stdarg.h>
 #include <sys/syscall.h>
 
+#include "alias.h"
 #include "restrict.c"
 
 static int
@@ -29,4 +30,4 @@ __open (char const *file_name, int flags, ...)
   return sys_open (file_name, flags, va_arg (p, int));
 }
 
-int open (char const *file_name, int flags, ...) __attribute__ ((alias ("__open")));
+safe_alias (__open, open);

--- a/librestrict/restrict-stat.c
+++ b/librestrict/restrict-stat.c
@@ -8,6 +8,7 @@
 #include <sys/stat.h>
 #include <sys/syscall.h>
 
+#include "alias.h"
 #include "restrict.c"
 
 static int sys_lstat (char const *file_name, struct stat *buf)
@@ -26,7 +27,7 @@ __lstat (char const *file_name, struct stat *buf)
   return sys_lstat (file_name, buf);
 }
 
-int lstat (char const *file_name, struct stat *buf)  __attribute__ ((alias ("__lstat")));
+safe_alias (__lstat, lstat);
 
 static int sys_oldstat (char const *file_name, struct stat *buf)
 {
@@ -44,7 +45,7 @@ __oldstat (char const *file_name, struct stat *buf)
   return sys_oldstat (file_name, buf);
 }
 
-int oldstat (char const *file_name, struct stat *buf)  __attribute__ ((alias ("__oldstat")));
+safe_alias (__oldstat, oldstat);
 
 static int sys_stat (char const *file_name, struct stat *buf)
 {
@@ -62,7 +63,7 @@ __stat (char const *file_name, struct stat *buf)
   return sys_stat (file_name, buf);
 }
 
-int stat (char const *file_name, struct stat *buf)  __attribute__ ((alias ("__stat")));
+safe_alias (__stat, stat);
 
 #ifdef SYS_ustat
 static int sys_ustat (char const *file_name, struct stat *buf)
@@ -81,7 +82,7 @@ __ustat (char const *file_name, struct stat *buf)
   return sys_ustat (file_name, buf);
 }
 
-int ustat (char const *file_name, struct stat *buf)  __attribute__ ((alias ("__ustat")));
+safe_alias (__ustat, ustat);
 #endif /* SYS_ustat */
 
 #ifdef __linux__
@@ -138,6 +139,6 @@ __xstat (int ver, char const *file_name, struct stat *buf)
   return sys_xstat (ver, file_name, buf);
 }
 
-int xstat (int ver, char const *file_name, struct stat *buf)  __attribute__ ((alias ("__xstat")));
+safe_alias (__xstat, xstat);
 
 #endif /* __linux__ */


### PR DESCRIPTION
`librestrict` (source in the top-level directory of GUB) uses C aliases. Darwin (the underlying operating system that macOS is built on) does not support aliases, thus `librestrict` can not currently be compiled on macOS. This commit defines a `safe_alias` macro that smooths over this missing feature by providing the current behavion on non-darwin systems and providing a workaround on darwin systems. The macro is defined in the `alias.h` file inside the librestrict directory.