### PR TITLE
Add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,38 @@
+Jan Nieuwenhuizen <janneke@gnu.org> <Jan Nieuwenhuizen janneke@gnu.org>
+Jan Nieuwenhuizen <janneke@gnu.org> <janneke@esur.localdomain>
+Jan Nieuwenhuizen <janneke@gnu.org> <janneke@janneke.ddns.htc.nl.philips.com>
+Jan Nieuwenhuizen <janneke@gnu.org> <janneke@peder.flower>
+Jan Nieuwenhuizen <janneke@gnu.org> janneke <janneke@gnu.org>
+
+Han-Wen Nienhuys <hanwen@lilypond.org> <hanwen@xs4all.nl>
+Han-Wen Nienhuys <hanwen@lilypond.org> hanwen <hanwen@lilypond.org>
+Han-Wen Nienhuys <hanwen@lilypond.org> hanwen <hanwen@xs4all.nl>
+Han-Wen Nienhuys <hanwen@lilypond.org> lilytest <hanwen@xs4all.nl>
+
+Boris-Chengbiao Zhou <bobo1239@web.de>
+Carl Sorensen <c_sorensen@byu.edu>
+Colin Campbell <colinpkcampbell@gmail.com>
+Colin Hall <colinghall@gmail.com>
+Eddy Pronk <epronk@muftor.com>
+Erik Sandberg <mandolaerik@gmail.com>
+Federico Bruni <fede@inventati.org>
+Graham Percival <graham@percival-music.ca> <gperciva@gperciva-desktop.(none)>
+Hans Aikema <hans.aikema@aikebah.net> <aikebah@aikebah.net>
+Hin-Tak Leung <HinTak.Leung@gmail.com>
+Jahrme Risner <github@jahrme.com>
+Janek Warchoł <janek.lilypond@gmail.com>
+Joe Neeman <joeneeman@gmail.com>
+John Mandereau <john.mandereau@gmail.com>
+Joshua Leung <aligorith@hotmail.com>
+Julien Rioux <julien.rioux@gmail.com>
+Knut Petersen <knut_petersen@t-online.de>
+Mark Polesky <markpolesky@gmail.com> <markpolesky@yahoo.com>
+Masamichi Hosoda <trueroad@trueroad.jp> <trueroad@users.noreply.github.com>
+Mike Solomon <mike@apollinemike.com>
+Neil Puttock <n.puttock@gmail.com>
+Nils Gey <denemo@nilsgey.de>
+Patrick McCarty <pnorcks@gmail.com> <address@hidden>
+Phil Holmes <mail@philholmes.net> PhilHolmes <PhilEHolmes@gmail.com>
+Reinhold Kainhofer <lilypond@kainhofer.com>
+Valentin Villenave <valentin@villenave.net>
+Werner Lemberg <wl@gnu.org>


### PR DESCRIPTION
While not essential, I prefer (and suspect others might prefer) having a `.mailmap` canonicalize authors/committers so that when reading the output of commands that show author/committer information (e.g., `git blame`, `git log`, etc.) the output is more consistent which helps with skimming. This is especially true given that the two authors who have committed the most work (Jan Nieuwenhuizen and Han-Wen Nienhuys) also have the greatest variety in both email and name used to commit.