### PR TITLE
Changes for native build on Arch Linux

### DIFF
--- a/bin/build-architecture
+++ b/bin/build-architecture
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2008

--- a/bin/build-platform
+++ b/bin/build-platform
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2008

--- a/bin/cygwin-packager
+++ b/bin/cygwin-packager
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 
 """

--- a/bin/gib
+++ b/bin/gib
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2008

--- a/bin/gpkg
+++ b/bin/gpkg
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     gpkg - GUB package manager

--- a/bin/gub
+++ b/bin/gub
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2008

--- a/bin/gub-tester
+++ b/bin/gub-tester
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 def argv0_relocation ():
     import os, sys

--- a/bin/gupdate
+++ b/bin/gupdate
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2009

--- a/gub.make
+++ b/gub.make
@@ -1,5 +1,5 @@
 CWD:=$(shell pwd)
-PYTHON=python
+PYTHON=python2
 PYTHONPATH=.
 export PYTHONPATH
 

--- a/gub/distcc.py
+++ b/gub/distcc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os
 import re

--- a/gub/runner.py
+++ b/gub/runner.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 """
     Copyright (c) 2005--2007

--- a/gub/specs/cygwin/guile.py
+++ b/gub/specs/cygwin/guile.py
@@ -22,9 +22,6 @@ CFLAGS='-O2 -DHAVE_CONFIG_H=1 -I%(builddir)s'
     build_number = '2'
     EXE = '.exe'
     install_command = guile.Guile.install_command + ' install-info'
-    def autopatch (self):
-        # we want info docs in cygwin
-        pass
     def category_dict (self):
         return {'': 'Interpreters'}
     # C&P from guile.Guile__mingw

--- a/gub/specs/fontforge.py
+++ b/gub/specs/fontforge.py
@@ -40,6 +40,9 @@ class Fontforge__tools (tools.AutoBuild):
                 + ' --without-freetype-src'
                 + ' --disable-libff '
                 + ' --enable-double '
+                # force disable cairo and pango
+                + ' --without-cairo '
+                + ' --without-pango '
                 # let's ignore python (and its dynamic link intracies
                 # for now).
                 + ' --without-python')

--- a/gub/specs/guile.py
+++ b/gub/specs/guile.py
@@ -65,31 +65,12 @@ LIBRARY_PATH=
                                                source)
         self.so_version = '17'
     def patch (self):
-        self.dump ('''#!/bin/sh
-exec %(tools_prefix)s/bin/guile "$@"
-''', "%(srcdir)s/pre-inst-guile.in")
-        #self.autopatch ()
         # Guile's texi files can not be compiled by texinfo-6.1.
         self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
                        '%(srcdir)s/doc/Makefile.am')
         self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
                        '%(srcdir)s/doc/Makefile.in')
         target.AutoBuild.patch (self)
-    def autopatch (self):
-        self.file_sub ([(r'AC_CONFIG_SUBDIRS\(guile-readline\)', '')],
-                       '%(srcdir)s/configure.in')
-        self.file_sub ([(r'guile-readline', '')],
-                       '%(srcdir)s/Makefile.am')
-        # Guile [doc] does not compile with dash *and* not with
-        # librestrict-stat.so; patch out.
-        if isinstance (self.source, repository.Git):
-            self.file_sub ([(' doc ', ' ')], '%(srcdir)s/Makefile.am')
-            self.file_sub ([('guile-readline', '')], '%(srcdir)s/Makefile.am')
-        else:
-            self.file_sub ([(' doc ', ' ')], '%(srcdir)s/Makefile.in')
-            self.file_sub ([('guile-readline', '')], '%(srcdir)s/Makefile.in')
-        self.dump ('', '%(srcdir)s/doc/ref/version.texi')
-        self.dump ('', '%(srcdir)s/doc/tutorial/version.texi')
     def compile (self):
         ## Ugh: broken dependencies break parallel build with make -jX
         self.system ('cd %(builddir)s/libguile && make %(compile_flags_native)s gen-scmconfig guile_filter_doc_snarfage')
@@ -222,14 +203,6 @@ LDFLAGS='-L%(system_prefix)s/lib %(rpath)s'
     # setting the proper LD_LIBRARY_PATH.
     compile_command = ('export LD_LIBRARY_PATH=%(builddir)s/libguile/.libs:%(system_prefix)s/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH};'
                 + Guile.compile_command)
-    def patch (self):
-        # Guile's texi files can not be compiled by texinfo-6.1.
-        self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
-                       '%(srcdir)s/doc/Makefile.am')
-        self.file_sub ([(r'SUBDIRS = ref tutorial goops r5rs', 'SUBDIRS =')],
-                       '%(srcdir)s/doc/Makefile.in')
-        tools.AutoBuild.patch (self)
-        #Guile.autopatch (self)
     def install (self):
         tools.AutoBuild.install (self)
         self.system ('cd %(install_root)s%(packaging_suffix_dir)s%(prefix_dir)s/bin && cp guile guile-1.8')

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -245,7 +245,7 @@ class LilyPond__darwin (LilyPond):
                 ])
     configure_flags = (LilyPond.configure_flags
                 .replace ('--enable-rpath', '--disable-rpath'))
-    make_flags = ' TARGET_PYTHON="/usr/bin/env python"'
+    make_flags = ' TARGET_PYTHON="/usr/bin/env python2"'
 
 class LilyPond__darwin__ppc (LilyPond__darwin):
     def configure (self):

--- a/gub/specs/python.py
+++ b/gub/specs/python.py
@@ -52,6 +52,8 @@ BLDLIBRARY='%(rpath)s -L. -lpython$(VERSION)'
         target.AutoBuild.patch (self)
         self.file_sub ([('@CC@', '@CC@ -I$(shell pwd)')],
                         '%(srcdir)s/Makefile.pre.in')
+        self.file_sub ([('@LDSHARED@', '@LDSHARED@ $(LDFLAGS)')],
+                        '%(srcdir)s/Makefile.pre.in')
     def autoupdate (self):
         target.AutoBuild.autoupdate (self)
         # FIXME: REMOVEME/PROMOTEME to target.py?
@@ -192,22 +194,6 @@ class Python__tools (tools.AutoBuild, Python):
     force_autoupdate = True
     parallel_build_broken = True
     # Use gcc-7 if it is available. Python 2.4.5 seems to incompatible to gcc-8!
-    # LD_LIBRARY_PATH and python wrapper script are needed for ubuntu 18.04
     configure_command = ('if [ "A`which gcc-7 2>>/dev/null`" != "A" ]; then export CC=gcc-7 ; fi; '
-                         +'LD_LIBRARY_PATH=%(system_prefix)s/lib '
                          + tools.AutoBuild.configure_command)
-    compile_command = ('LD_LIBRARY_PATH=%(system_prefix)s/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} '
-                         + tools.AutoBuild.compile_command)
-    install_command = ('LD_LIBRARY_PATH=%(system_prefix)s/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} '
-                         + tools.AutoBuild.install_command)
     make_flags = Python.make_flags + ' LIBC="-lcrypt -ldb" '
-    def patch (self):
-        Python.patch (self)
-    def install (self):
-        Python.install (self)
-        self.system ('''
-mv %(install_prefix)s/bin/python %(install_prefix)s/bin/_python
-echo '#!/bin/sh' > %(install_prefix)s/bin/python
-echo 'LD_LIBRARY_PATH=%(system_prefix)s/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH} %(system_prefix)s/bin/_python "$@"' >> %(install_prefix)s/bin/python
-chmod 755 %(install_prefix)s/bin/python
-''')

--- a/gub/versiondb.py
+++ b/gub/versiondb.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
     Copyright (c) 2005--2007

--- a/gub/with-lock.py
+++ b/gub/with-lock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 
 """

--- a/test-lily/cron-builder.py
+++ b/test-lily/cron-builder.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 # FIXME: replace `lilypond' with $package to make generic tester
 

--- a/test-lily/dist-check.py
+++ b/test-lily/dist-check.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 def argv0_relocation ():
     import os, sys

--- a/test-lily/rsync-lily-doc.py
+++ b/test-lily/rsync-lily-doc.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 def argv0_relocation ():
     import os, sys

--- a/test-lily/rsync-test.py
+++ b/test-lily/rsync-test.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import os
 import re

--- a/test-lily/test-binary.py
+++ b/test-lily/test-binary.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 import sys
 import os

--- a/test-lily/upload.py
+++ b/test-lily/upload.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 maintainer = "graham"
 maintainer_git_username = "philholmes"


### PR DESCRIPTION
With these patches, I'm able to use gub natively on Arch Linux. I verified that the changes still work on LilyDev (based on Debian) and Ubuntu 18.04 LTS