### PR TITLE
Python 3

### DIFF
--- a/gub/specs/autoconf.py
+++ b/gub/specs/autoconf.py
@@ -1,7 +1,7 @@
 from gub import tools
 
 class Autoconf__tools (tools.AutoBuild):
-    source = 'http://ftp.gnu.org/pub/gnu/autoconf/autoconf-2.63.tar.gz'
+    source = 'http://ftp.gnu.org/pub/gnu/autoconf/autoconf-2.69.tar.xz'
     parallel_build_broken = True
     dependencies = [
             'm4',

--- a/gub/specs/automake.py
+++ b/gub/specs/automake.py
@@ -1,7 +1,7 @@
 from gub import tools
 
 class Automake__tools (tools.AutoBuild):
-    source = 'http://ftp.gnu.org/pub/gnu/automake/automake-1.10.1.tar.gz'
+    source = 'http://ftp.gnu.org/pub/gnu/automake/automake-1.16.1.tar.gz'
     dependencies = ['autoconf']
     configure_variables = (tools.AutoBuild.configure_variables
                            + ' AUTOM4TE=%(tools_prefix)s/bin/autom4te'

--- a/gub/specs/python-2-6.py
+++ b/gub/specs/python-2-6.py
@@ -66,7 +66,7 @@ ac_cv_py_format_size_t=no
 class Python_2_6__tools (python.Python__tools):
     source = Python_2_6.source
     patches = []
-    dependencies = ['autoconf', 'libtool']
+    dependencies = ['autoconf', 'db', 'libtool']
     force_autoupdate = True
     make_flags = python.Python__tools.make_flags
     so_modules = Python_2_6.so_modules

--- a/gub/specs/python3.py
+++ b/gub/specs/python3.py
@@ -1,0 +1,33 @@
+from gub import misc
+from gub import target
+from gub import tools
+
+class Python3 (target.AutoBuild):
+    source = 'https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz'
+    dependencies = ['tools::python3']
+
+    python_configure_flags = misc.join_lines('''
+--disable-shared
+--enable-static
+--without-ensurepip
+''')
+    configure_flags = (target.AutoBuild.configure_flags + python_configure_flags
+        + misc.join_lines('''
+--disable-ipv6
+PYTHON_FOR_BUILD=%(tools_prefix)s/bin/python3
+'''))
+# Adding --disable-ipv6 is a simple "fix" for Python 3.7.4 complaining:
+#    checking getaddrinfo bug... yes
+#    Fatal: You must get working getaddrinfo() function.
+#           or you can specify "--disable-ipv6".
+# This might be because our glibc is too old. As we don't do network, this
+# shouldn't be too bad...
+
+    def patch (self):
+        # Make setup.py work with tools::python3 as PYTHON_FOR_BUILD.
+        self.file_sub ([('srcdir = sysconfig.*', 'srcdir = \'%(srcdir)s\'')],
+                       '%(srcdir)s/setup.py')
+        target.AutoBuild.patch (self)
+
+class Python3__tools (tools.AutoBuild, Python3):
+    configure_flags = (tools.AutoBuild.configure_flags + Python3.python_configure_flags)

--- a/gub/specs/python3.py
+++ b/gub/specs/python3.py
@@ -36,6 +36,16 @@ PYTHON_FOR_BUILD=%(tools_prefix)s/bin/python3
                        '%(srcdir)s/setup.py')
         target.AutoBuild.patch (self)
 
+class Python3__darwin (Python3):
+    patches = Python3.patches + [
+        'python-3.7.4-configure.ac-darwin.patch'
+    ]
+    force_autoupdate = True
+    configure_flags = Python3.configure_flags + misc.join_lines('''
+READELF=/usr/bin/readelf
+MACOSX_DEPLOYMENT_TARGET=10.3
+''')
+
 class Python3__mingw (build.BinaryBuild):
     source = PYTHON_WIN
 

--- a/gub/specs/python3.py
+++ b/gub/specs/python3.py
@@ -1,9 +1,16 @@
+from gub import build
 from gub import misc
 from gub import target
 from gub import tools
 
+PYTHON_VERSION_MAJOR = '3.7'
+PYTHON_VERSION_PATCH = '4'
+PYTHON_VERSION = '%s.%s' % (PYTHON_VERSION_MAJOR, PYTHON_VERSION_PATCH)
+PYTHON_SRC = 'https://www.python.org/ftp/python/%(ver)s/Python-%(ver)s.tar.xz' % {'ver': PYTHON_VERSION}
+PYTHON_WIN = 'https://www.python.org/ftp/python/%(ver)s/python-%(ver)s-embed-win32.zip' % {'ver': PYTHON_VERSION}
+
 class Python3 (target.AutoBuild):
-    source = 'https://www.python.org/ftp/python/3.7.4/Python-3.7.4.tar.xz'
+    source = PYTHON_SRC
     dependencies = ['tools::python3']
 
     python_configure_flags = misc.join_lines('''
@@ -28,6 +35,19 @@ PYTHON_FOR_BUILD=%(tools_prefix)s/bin/python3
         self.file_sub ([('srcdir = sysconfig.*', 'srcdir = \'%(srcdir)s\'')],
                        '%(srcdir)s/setup.py')
         target.AutoBuild.patch (self)
+
+class Python3__mingw (build.BinaryBuild):
+    source = PYTHON_WIN
+
+    python_zip = 'python%s.zip' % PYTHON_VERSION_MAJOR.replace ('.', '')
+    def install (self):
+        self.system ('''
+mkdir -p %(install_prefix)s/bin
+cp %(srcdir)s/*.exe %(install_prefix)s/bin/
+cp %(srcdir)s/*.dll %(install_prefix)s/bin/
+cp %(srcdir)s/*.pyd %(install_prefix)s/bin/
+cp %(srcdir)s/%(python_zip)s -d %(install_prefix)s/bin/
+''')
 
 class Python3__tools (tools.AutoBuild, Python3):
     configure_flags = (tools.AutoBuild.configure_flags + Python3.python_configure_flags)

--- a/patches/python-3.7.4-configure.ac-darwin.patch
+++ b/patches/python-3.7.4-configure.ac-darwin.patch
@@ -1,0 +1,54 @@
+--- python3-3.7.4.orig/configure.ac	2019-10-17 09:10:00.930927301 +0200
++++ python3-3.7.4/configure.ac	2019-10-17 09:42:06.272359210 +0200
+@@ -379,12 +379,15 @@
+ 	*-*-cygwin*)
+ 		ac_sys_system=Cygwin
+ 		;;
++	*-*-darwin*)
++		ac_sys_system=Darwin
++		ac_sys_release=8.0
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+ 		AC_MSG_ERROR([cross build not supported for $host])
+ 	esac
+-	ac_sys_release=
+     else
+ 	ac_sys_system=`uname -s`
+ 	if test "$ac_sys_system" = "AIX" \
+@@ -423,6 +426,9 @@
+ 	*-*-cygwin*)
+ 		_host_cpu=
+ 		;;
++	*-*-darwin*)
++		_host_cpu=
++		;;
+ 	*)
+ 		# for now, limit cross builds to known configurations
+ 		MACHDEP="unknown"
+@@ -2417,7 +2423,7 @@
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -install_name $(PYTHONFRAMEWORKINSTALLDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+     LIBTOOL_CRUFT=$LIBTOOL_CRUFT' -compatibility_version $(VERSION) -current_version $(VERSION)';;
+   Darwin/*)
+-    gcc_version=`gcc -dumpversion`
++    gcc_version=`$CC -dumpversion`
+     if test ${gcc_version} '<' 4.0
+         then
+             LIBTOOL_CRUFT="-lcc_dynamic"
+@@ -2437,11 +2443,12 @@
+     ]])],[ac_osx_32bit=yes],[ac_osx_32bit=no],[ac_osx_32bit=yes])
+ 
+     if test "${ac_osx_32bit}" = "yes"; then
+-    	case `/usr/bin/arch` in
+-    	i386)
++    	machine=`$CC -dumpmachine`
++    	case $machine in
++    	i686*)
+     		MACOSX_DEFAULT_ARCH="i386"
+     		;;
+-    	ppc)
++    	powerpc*)
+     		MACOSX_DEFAULT_ARCH="ppc"
+     		;;
+     	*)


### PR DESCRIPTION
These changes add a spec for building Python 3.7.4, for now unused. I tested compilation on linux-64, linux-x86, linux-ppc, darwin-x86, and darwin-ppc; for Windows I chose to use the [embeddable package](https://docs.python.org/3.7/using/windows.html#windows-embeddable) because apparently Python 3 for Windows expects to be built with Visual Studio.