### PR TITLE
Prepare for LilyPond 2.21

### DIFF
--- a/gub/specs/bison.py
+++ b/gub/specs/bison.py
@@ -1,4 +1,4 @@
 from gub import tools
 
 class Bison__tools (tools.AutoBuild):
-    source = 'http://ftp.gnu.org/pub/gnu/bison/bison-2.3.tar.gz'
+    source = 'http://ftp.gnu.org/pub/gnu/bison/bison-3.5.2.tar.gz'

--- a/gub/specs/guile.py
+++ b/gub/specs/guile.py
@@ -107,6 +107,7 @@ exit 0
         self.system ('cd %(install_prefix)s%(cross_dir)s/bin && cp -pv %(target_architecture)s-guile-config guile-config')
 
 class Guile__mingw (Guile):
+    patches = Guile.patches + ['guile-1.8.7-mingw-copysign.patch']
     def __init__ (self, settings, source):
         Guile.__init__ (self, settings, source)
         # Configure (compile) without -mwindows for console

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -34,7 +34,7 @@ sheet music from a high-level description file.'''
         'ghostscript',
         'guile-devel',
         'pango-devel',
-        'python-devel',
+        'python3-devel',
         'tools::fonts-texgyre',
         'tools::fonts-urw-core35',
 
@@ -69,7 +69,7 @@ sheet music from a high-level description file.'''
                        + ' --with-texgyre-dir=%(tools_prefix)s/share/fonts/opentype/texgyre'
                        + ' --with-urwotf-dir=%(tools_prefix)s/share/fonts/opentype/urw-core35'
                        )
-    make_flags = ' TARGET_PYTHON=/usr/bin/python'
+    make_flags = ' TARGET_PYTHON=/usr/bin/python3'
 
     if 'stat' in misc.librestrict ():
         home = os.environ['HOME']
@@ -121,9 +121,6 @@ sheet music from a high-level description file.'''
         self.system ('cd %(install_prefix)s/share/lilypond && mv %(installer_version)s current',
                      locals ())
 
-        self.system ('cd %(install_prefix)s/lib/lilypond && mv %(installer_version)s current',
-                     locals ())
-
         self.system ('mkdir -p %(install_prefix)s/etc/fonts/')
         self.dump ('''\
 <fontconfig>
@@ -155,7 +152,7 @@ class LilyPond__freebsd (LilyPond):
 ## shortcut: take python out of dependencies
 class LilyPond__no_python (LilyPond):
     dependencies = [x for x in LilyPond.dependencies
-                if x != 'python-devel']
+                if x != 'python3-devel']
     def configure (self):
         self.system ('mkdir -p %(builddir)s || true') 
         self.system ('touch %(builddir)s/Python.h') 
@@ -224,7 +221,7 @@ class LilyPond__darwin (LilyPond):
                 ])
     configure_flags = (LilyPond.configure_flags
                 .replace ('--enable-rpath', '--disable-rpath'))
-    make_flags = ' TARGET_PYTHON="/usr/bin/env python2"'
+    make_flags = ' TARGET_PYTHON="/usr/bin/env python3"'
 
 class LilyPond__darwin__ppc (LilyPond__darwin):
     def configure (self):

--- a/gub/specs/lilypond.py
+++ b/gub/specs/lilypond.py
@@ -215,27 +215,6 @@ cp %(install_prefix)s/share/lilypond/*/python/* %(install_prefix)s/bin
             
         self.dump (bat, '%(install_prefix)s/bin/lilypond-windows.bat.in')
 
-class LilyPond__debian (LilyPond):
-    def get_dependency_dict (self): #debian
-        from gub import debian, gup
-        return {'': gup.gub_to_distro_deps (LilyPond.get_dependency_dict (self)[''],
-                                            debian.gub_to_distro_dict)}
-    def install (self):
-        target.AutoBuild.install (self)
-    def get_build_dependencies (self): # debian
-        #FIXME: aargh, MUST specify gs,  etc here too.
-        return [
-            'gettext',
-            'guile-1.8-dev',
-            'libfontconfig1-dev',
-            'libfreetype6-dev',
-            'libglib2.0-dev',
-            'python2.4-dev',
-            'libpango1.0-dev',
-            'zlib1g-dev',
-            'urw-fonts',
-            ] + ['gs']
-
 class LilyPond__darwin (LilyPond):
     dependencies = (LilyPond.dependencies
                 # FIXME: move to lilypond-installer.py, see __mingw.
@@ -314,8 +293,5 @@ Lilypond_base = LilyPond_base
 Lilypond = LilyPond
 Lilypond__darwin = LilyPond__darwin
 Lilypond__darwin__ppc = LilyPond__darwin__ppc
-Lilypond__debian = LilyPond__debian
-Lilypond__debian_arm = LilyPond__debian
 Lilypond__freebsd = LilyPond__freebsd
 Lilypond__mingw = LilyPond__mingw
-Lilypond__mipsel = LilyPond__debian

--- a/gub/specs/python3.py
+++ b/gub/specs/python3.py
@@ -21,7 +21,6 @@ class Python3 (target.AutoBuild):
     configure_flags = (target.AutoBuild.configure_flags + python_configure_flags
         + misc.join_lines('''
 --disable-ipv6
-PYTHON_FOR_BUILD=%(tools_prefix)s/bin/python3
 '''))
 # Adding --disable-ipv6 is a simple "fix" for Python 3.7.4 complaining:
 #    checking getaddrinfo bug... yes
@@ -30,13 +29,7 @@ PYTHON_FOR_BUILD=%(tools_prefix)s/bin/python3
 # This might be because our glibc is too old. As we don't do network, this
 # shouldn't be too bad...
 
-    def patch (self):
-        # Make setup.py work with tools::python3 as PYTHON_FOR_BUILD.
-        self.file_sub ([('srcdir = sysconfig.*', 'srcdir = \'%(srcdir)s\'')],
-                       '%(srcdir)s/setup.py')
-        target.AutoBuild.patch (self)
-
-class Python3__darwin (Python3):
+class Python3__darwin__x86 (Python3):
     patches = Python3.patches + [
         'python-3.7.4-configure.ac-darwin.patch'
     ]
@@ -44,6 +37,17 @@ class Python3__darwin (Python3):
     configure_flags = Python3.configure_flags + misc.join_lines('''
 READELF=/usr/bin/readelf
 MACOSX_DEPLOYMENT_TARGET=10.3
+ac_cv_little_endian_double=yes
+''')
+
+class Python3__linux__x86 (Python3):
+    configure_flags = Python3.configure_flags + misc.join_lines('''
+ac_cv_little_endian_double=yes
+''')
+
+class Python3__linux__64 (Python3):
+    configure_flags = Python3.configure_flags + misc.join_lines('''
+ac_cv_little_endian_double=yes
 ''')
 
 class Python3__mingw (build.BinaryBuild):

--- a/lilypond.make
+++ b/lilypond.make
@@ -21,13 +21,19 @@ ALL_PLATFORMS=linux-x86 darwin-ppc darwin-x86 mingw linux-64 debian debian-arm f
 ALL_PLATFORMS += cygwin
 
 PLATFORMS=linux-x86
-PLATFORMS+=darwin-ppc darwin-x86
+# 20200302: Last hardware with PowerPC processors shipped in 2006, support was
+# removed with Mac OS X 10.6 in 2009 and Mac OS X 10.7 in 2011 dropped Rosetta
+# for executing PPC binaries on Intel processors.
+# PLATFORMS+=darwin-ppc
+PLATFORMS+=darwin-x86
 PLATFORMS+=mingw
 PLATFORMS+=linux-64
 PLATFORMS+=linux-ppc
 # Works for me, uncommentme!
 # PLATFORMS+=linux-mipsel
-PLATFORMS+=freebsd-x86 freebsd-64
+# 20200302: Binaries linked against GNU libc cannot be executed on a currently
+# supported release of FreeBSD (11.x and 12.x).
+# PLATFORMS+=freebsd-x86 freebsd-64
 # Put cygwin last, because it is not a core lilypond platform. 
 #PLATFORMS += cygwin
 

--- a/lilypond.make
+++ b/lilypond.make
@@ -28,7 +28,8 @@ PLATFORMS=linux-x86
 PLATFORMS+=darwin-x86
 PLATFORMS+=mingw
 PLATFORMS+=linux-64
-PLATFORMS+=linux-ppc
+# 20200303: This is 32-bit, very likely not relevant today.
+# PLATFORMS+=linux-ppc
 # Works for me, uncommentme!
 # PLATFORMS+=linux-mipsel
 # 20200302: Binaries linked against GNU libc cannot be executed on a currently

--- a/patches/guile-1.8.7-mingw-copysign.patch
+++ b/patches/guile-1.8.7-mingw-copysign.patch
@@ -1,0 +1,10 @@
+--- guile-1.8.7/libguile/numbers.h	2020-03-02 15:43:11.673024370 +0100
++++ guile-1.8.7/libguile/numbers.h	2020-03-02 15:43:27.876044196 +0100
+@@ -91,7 +91,6 @@
+ # ifndef GO32
+ #  include <float.h>
+ #  ifdef __MINGW32__
+-#   define copysign _copysign
+ #   define finite _finite
+ #  endif /* __MINGW32__ */
+ # endif /* ndef GO32 */

--- a/sourcefiles/lilypond-sharhead.sh
+++ b/sourcefiles/lilypond-sharhead.sh
@@ -209,7 +209,7 @@ chmod +x "$binwrapscript"
 
 wrapscript="${bindir}/%(name)s-wrapper"
 
-for interp in python guile; do
+for interp in python3 guile; do
     echo "Creating script $wrapscript.$interp"
 
     rm -f "$wrapscript.$interp" > /dev/null 2>&1
@@ -230,7 +230,7 @@ done
 cd ${bindir};
     for a in abc2ly musicxml2ly convert-ly midi2ly etf2ly lilypond-book mup2ly; do
 	rm -f $a;
-	ln -s $wrapscript.python $a;
+	ln -s $wrapscript.python3 $a;
 	binaries="$binaries $a"
     done
     for a in lilypond-invoke-editor; do
@@ -274,7 +274,7 @@ fi
 for binary in ${binaries}; do
     rm ${bindir}/${dollar}binary
 done
-rm -f $wrapscript.guile $wrapscript.python
+rm -f $wrapscript.guile $wrapscript.python3
 rm -rf ${prefix}
 rm $uninstall_script
 EOF

--- a/test-lily/rsync-lily-doc.py
+++ b/test-lily/rsync-lily-doc.py
@@ -156,7 +156,7 @@ def compute_distances (options, source):
 
     html = ''
     for d in version_dirs:
-        cmd = 'python %s %s %s ' % (options.output_distance_script,
+        cmd = 'python3 %s %s %s ' % (options.output_distance_script,
                                     d, cur_dir)
 
         base = os.path.split (d)[1]

--- a/test-lily/rsync-test.py
+++ b/test-lily/rsync-test.py
@@ -128,7 +128,7 @@ def compare_test_tarballs (options, version_file_tuples):
     html = ''
     for d in dirs[:-1]:
         cmd = ('cd %s '
-               '&& python %s --create-images --output-dir %s/compare-%s --local-datadir %s %s'
+               '&& python3 %s --create-images --output-dir %s/compare-%s --local-datadir %s %s'
                % (unpack_dir,
                   options.output_distance_script,
                   dest_dir, d, d, dirs[-1]))


### PR DESCRIPTION
Note: For future point releases of 2.20.x, just use a version of GUB before these changes are merged.

The changes work (as of now) with branch `dev/hahnjo/cross-mingw` which contains fixes for cross-compilation to mingw. Tested with
```
make LILYPOND_BRANCH=dev/hahnjo/cross-mingw lilypond
```