### PR TITLE
imagemagick: Disable OpenMP parallelization

### DIFF
--- a/gub/specs/imagemagick.py
+++ b/gub/specs/imagemagick.py
@@ -23,6 +23,7 @@ class ImageMagick__tools (tools.AutoBuild):
                 + misc.join_lines ('''
 --without-magick-plus-plus
 --without-perl
+--disable-openmp
 '''))
     # Setting `CFLAGS' is not sufficient since ImageMagick's `configure'
     # script prepends stuff for libraries like libpng to `CFLAGS'.  We thus


### PR DESCRIPTION
This leads to problems on Arch Linux when tools::imagemagick, built
by the system GCC, is executed with an LD_LIBRARY_PATH that includes
GCC libraries from linux-64.