### PR TITLE
Fix --doc option of LilyPond UNIX installers

### DIFF
--- a/sourcefiles/lilypond-sharhead.sh
+++ b/sourcefiles/lilypond-sharhead.sh
@@ -290,7 +290,7 @@ doc_url_base="$mirror/binaries/documentation"
 if test "$doc" = yes; then
     documentation="file://${prefix}/usr/share/doc/lilypond/html/index.html
     file://${prefix}/usr/share/info/dir"
-    docball=`echo $me | sed -e 's/[.][^.]\+[.]sh/.documentation.tar.bz2/'`
+    docball=`basename $me | sed -e 's/[.][^.]\+[.]sh/.documentation.tar.bz2/'`
     doc_url="$doc_url_base/$docball"
     if ! test -e $docball; then
 	echo "No ./$docball found, downloading."


### PR DESCRIPTION
As reported at
https://lists.gnu.org/archive/html/lilypond-user/2020-07/msg00119.html
and tracked at
https://gitlab.com/lilypond/lilypond/-/issues/3768,
when the installers are called with qualified path, the --doc option
stops working. David Sumbler diagnosed the problem as an incorrect path
for searching the docs on the website. Fix this by extracting the base
name of $me.

A better fix would be to record the version in the script upon
generation to make it work even when renamed. For now, this seems
good enough.